### PR TITLE
Migrate Kotlin synthetics to ViewBinding

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 apply from: "../buildsystem/jacoco.gradle"
 

--- a/buildsystem/activity.gradle
+++ b/buildsystem/activity.gradle
@@ -3,6 +3,7 @@ apply from: "../buildsystem/submodule.gradle"
 android {
     buildFeatures {
         dataBinding = true
+        viewBinding = true
     }
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/buildsystem/submodule.gradle
+++ b/buildsystem/submodule.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
+apply plugin: 'kotlin-parcelize'
 apply plugin: 'kotlin-kapt'
 apply from: "../buildsystem/jacoco.gradle"
 

--- a/chat/src/main/java/com/amity/socialcloud/uikit/chat/editMessage/AmityEditMessageActivity.kt
+++ b/chat/src/main/java/com/amity/socialcloud/uikit/chat/editMessage/AmityEditMessageActivity.kt
@@ -14,8 +14,6 @@ import com.amity.socialcloud.uikit.chat.R
 import com.amity.socialcloud.uikit.chat.databinding.AmityActivityEditMessageBinding
 import com.amity.socialcloud.uikit.common.base.AmityBaseActivity
 import io.reactivex.disposables.Disposable
-import kotlinx.android.synthetic.main.amity_activity_edit_message.*
-import kotlinx.android.synthetic.main.amity_edit_msg_bar.view.*
 
 class AmityEditMessageActivity :
     AmityBaseActivity<AmityActivityEditMessageBinding, AmityEditMessageViewModel>() {
@@ -39,20 +37,20 @@ class AmityEditMessageActivity :
         editMessageViewModel.saveColor.set(ContextCompat.getColor(this, R.color.amityColorPrimary))
         setUpToolbar()
         getMessage()
-        lMessage.setOnClickListener {
+        mViewDataBinding.lMessage.setOnClickListener {
             requestFocus()
         }
     }
 
     private fun setUpToolbar() {
         supportActionBar?.displayOptions = ActionBar.DISPLAY_SHOW_CUSTOM
-        setSupportActionBar(emToolBar as Toolbar)
+        setSupportActionBar(mViewDataBinding.emToolBar as Toolbar)
 
-        emToolBar.icCross.setOnClickListener {
+        mViewDataBinding.emToolBar.icCross.setOnClickListener {
             this.finish()
         }
 
-        emToolBar.tvSave.setOnClickListener {
+        mViewDataBinding.emToolBar.tvSave.setOnClickListener {
             editMessageDisposable = editMessageViewModel.saveMessage().subscribe()
             this.finish()
         }
@@ -92,12 +90,12 @@ class AmityEditMessageActivity :
     override fun getBindingVariable(): Int = BR.viewModel
 
     private fun requestFocus() {
-        etMessage.postDelayed({
-            etMessage.requestFocusFromTouch()
-            etMessage.setSelection(etMessage.text?.length ?: 0)
+        mViewDataBinding.etMessage.postDelayed({
+            mViewDataBinding.etMessage.requestFocusFromTouch()
+            mViewDataBinding.etMessage.setSelection(mViewDataBinding.etMessage.text?.length ?: 0)
             val inputManager: InputMethodManager =
                 getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
-            inputManager.showSoftInput(etMessage, 0)
+            inputManager.showSoftInput(mViewDataBinding.etMessage, 0)
         }, 300)
 
     }

--- a/chat/src/main/java/com/amity/socialcloud/uikit/chat/home/fragment/AmityChatHomePageFragment.kt
+++ b/chat/src/main/java/com/amity/socialcloud/uikit/chat/home/fragment/AmityChatHomePageFragment.kt
@@ -8,6 +8,7 @@ import androidx.appcompat.widget.Toolbar
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import com.amity.socialcloud.uikit.chat.R
+import com.amity.socialcloud.uikit.chat.databinding.AmityFragmentChatHomePageBinding
 import com.amity.socialcloud.uikit.chat.directory.fragment.AmityDirectoryFragment
 import com.amity.socialcloud.uikit.chat.home.AmityChatHomePageViewModel
 import com.amity.socialcloud.uikit.chat.home.callback.AmityDirectoryFragmentDelegate
@@ -15,11 +16,13 @@ import com.amity.socialcloud.uikit.chat.home.callback.AmityRecentChatFragmentDel
 import com.amity.socialcloud.uikit.chat.home.callback.AmityRecentChatItemClickListener
 import com.amity.socialcloud.uikit.chat.recent.fragment.AmityRecentChatFragment
 import com.amity.socialcloud.uikit.common.base.AmityFragmentStateAdapter
-import kotlinx.android.synthetic.main.amity_fragment_chat_home_page.*
 
 class AmityChatHomePageFragment private constructor() : Fragment() {
     private lateinit var mViewModel: AmityChatHomePageViewModel
     private lateinit var fragmentStateAdapter: AmityFragmentStateAdapter
+
+    private var _binding: AmityFragmentChatHomePageBinding? = null
+    private val binding get() = _binding!!
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -34,7 +37,8 @@ class AmityChatHomePageFragment private constructor() : Fragment() {
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        return inflater.inflate(R.layout.amity_fragment_chat_home_page, container, false)
+        _binding = AmityFragmentChatHomePageBinding.inflate(inflater, container, false)
+        return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -44,10 +48,10 @@ class AmityChatHomePageFragment private constructor() : Fragment() {
     }
 
     private fun initToolbar() {
-        chatHomeToolBar.setLeftString(getString(R.string.amity_chat))
+        binding.chatHomeToolBar.setLeftString(getString(R.string.amity_chat))
         (activity as AppCompatActivity).supportActionBar?.displayOptions =
             ActionBar.DISPLAY_SHOW_CUSTOM
-        (activity as AppCompatActivity).setSupportActionBar(chatHomeToolBar as Toolbar)
+        (activity as AppCompatActivity).setSupportActionBar(binding.chatHomeToolBar as Toolbar)
         setHasOptionsMenu(true)
     }
 
@@ -60,7 +64,7 @@ class AmityChatHomePageFragment private constructor() : Fragment() {
                 )
             )
         )
-        tabLayout.setAdapter(fragmentStateAdapter)
+        binding.tabLayout.setAdapter(fragmentStateAdapter)
     }
 
     private fun getRecentChatFragment(): Fragment {
@@ -101,6 +105,10 @@ class AmityChatHomePageFragment private constructor() : Fragment() {
         //startActivity(intent)
     }
 
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
 
     class Builder internal constructor(){
 

--- a/chat/src/main/java/com/amity/socialcloud/uikit/chat/messages/fragment/AmityChatRoomWithDefaultComposeBarFragment.kt
+++ b/chat/src/main/java/com/amity/socialcloud/uikit/chat/messages/fragment/AmityChatRoomWithDefaultComposeBarFragment.kt
@@ -49,18 +49,14 @@ import com.google.android.material.snackbar.Snackbar
 import com.zhihu.matisse.Matisse
 import com.zhihu.matisse.MimeType
 import com.zhihu.matisse.engine.impl.GlideEngine
-import io.reactivex.Single
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.Disposable
 import io.reactivex.schedulers.Schedulers
-import kotlinx.android.synthetic.main.amity_chat_bar.view.*
-import kotlinx.android.synthetic.main.amity_fragment_chat_with_default_compose_bar.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import java.io.File
-import java.util.concurrent.TimeUnit
 
 class AmityChatRoomWithDefaultComposeBarFragment : AmityPickerFragment(),
     AmityAudioRecorderListener, AmityMessageListListener {
@@ -69,7 +65,7 @@ class AmityChatRoomWithDefaultComposeBarFragment : AmityPickerFragment(),
 
     private val messageListViewModel: AmityMessageListViewModel by viewModels()
     private lateinit var mAdapter: AmityMessageListAdapter
-    private lateinit var mBinding: AmityFragmentChatWithDefaultComposeBarBinding
+    private lateinit var binding: AmityFragmentChatWithDefaultComposeBarBinding
     private var msgSent = false
     private var viewHolderListener: AmityMessageListAdapter.CustomViewHolderListener? = null
     var recordPermissionGranted = false
@@ -115,10 +111,10 @@ class AmityChatRoomWithDefaultComposeBarFragment : AmityPickerFragment(),
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
-        mBinding = DataBindingUtil.inflate(inflater, R.layout.amity_fragment_chat_with_default_compose_bar, container, false)
-        mBinding.viewModel = messageListViewModel
-        return mBinding.root
+    ): View {
+        binding = DataBindingUtil.inflate(inflater, R.layout.amity_fragment_chat_with_default_compose_bar, container, false)
+        binding.viewModel = messageListViewModel
+        return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -135,21 +131,23 @@ class AmityChatRoomWithDefaultComposeBarFragment : AmityPickerFragment(),
     }
 
     private fun setupComposebar() {
-        etMessage.setShape(
-            null, null, null, null,
-            R.color.amityColorBase, R.color.amityColorBase, AmityColorShade.SHADE4
-        )
-        recordBackground.setShape(
-            null, null, null, null,
-            R.color.amityColorBase, R.color.amityColorBase, AmityColorShade.SHADE4
-        )
-        etMessage.setOnClickListener {
-            messageListViewModel.showComposeBar.set(false)
+        binding.apply {
+            etMessage.setShape(
+                null, null, null, null,
+                R.color.amityColorBase, R.color.amityColorBase, AmityColorShade.SHADE4
+            )
+            recordBackground.setShape(
+                null, null, null, null,
+                R.color.amityColorBase, R.color.amityColorBase, AmityColorShade.SHADE4
+            )
+            etMessage.setOnClickListener {
+                messageListViewModel.showComposeBar.set(false)
+            }
+            etMessage.setOnFocusChangeListener { _, _ ->
+                messageListViewModel.showComposeBar.set(false)
+            }
+            recorderView.setAudioRecorderListener(this@AmityChatRoomWithDefaultComposeBarFragment)
         }
-        etMessage.setOnFocusChangeListener { _, _ ->
-            messageListViewModel.showComposeBar.set(false)
-        }
-        mBinding.recorderView.setAudioRecorderListener(this)
     }
 
     private fun initMessageLoader() {
@@ -179,21 +177,21 @@ class AmityChatRoomWithDefaultComposeBarFragment : AmityPickerFragment(),
 
     private fun presentDisconnectedView() {
         if (essentialViewModel.enableConnectionBar) {
-            mBinding.connectionView.visibility = View.VISIBLE
-            mBinding.connectionTexview.setText(R.string.amity_no_internet)
-            mBinding.connectionTexview.setBackgroundColor(resources.getColor(R.color.amityColorGrey))
+            binding.connectionView.visibility = View.VISIBLE
+            binding.connectionTexview.setText(R.string.amity_no_internet)
+            binding.connectionTexview.setBackgroundColor(resources.getColor(R.color.amityColorGrey))
         }
     }
 
     private fun presentReconnectedView() {
         if (essentialViewModel.enableConnectionBar) {
-            mBinding.connectionView.visibility = View.GONE
+            binding.connectionView.visibility = View.GONE
         }
     }
 
     private fun presentChatRefreshLoadingView() {
-        mBinding.loadingView.setBackgroundColor(resources.getColor(R.color.amityTranslucentBackground))
-        mBinding.loadingView.visibility = View.VISIBLE
+        binding.loadingView.setBackgroundColor(resources.getColor(R.color.amityTranslucentBackground))
+        binding.loadingView.visibility = View.VISIBLE
     }
 
     private fun resetMessageLoader() {
@@ -208,11 +206,11 @@ class AmityChatRoomWithDefaultComposeBarFragment : AmityPickerFragment(),
     }
 
     override fun onMessageClicked(position: Int) {
-        rvChatList.scrollToPosition(position)
+        binding.rvChatList.scrollToPosition(position)
     }
 
     private fun observeScrollingState(layoutManager: LinearLayoutManager) {
-        rvChatList.addOnScrollListener(object : RecyclerView.OnScrollListener() {
+        binding.rvChatList.addOnScrollListener(object : RecyclerView.OnScrollListener() {
             override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
                 super.onScrolled(recyclerView, dx, dy)
                 val firstVisibleItem = layoutManager.findFirstVisibleItemPosition()
@@ -266,14 +264,14 @@ class AmityChatRoomWithDefaultComposeBarFragment : AmityPickerFragment(),
     private fun getChannelType() {
         disposable.add(messageListViewModel.getChannelType().take(1).subscribe { ekoChannel ->
             if (ekoChannel.getType() == AmityChannel.Type.STANDARD) {
-                mBinding.chatToolBar.ivAvatar.setImageDrawable(
+                binding.chatToolBar.ivAvatar.setImageDrawable(
                     ContextCompat.getDrawable(
                         requireContext(),
                         R.drawable.amity_ic_group
                     )
                 )
             } else {
-                mBinding.chatToolBar.ivAvatar.setImageDrawable(
+                binding.chatToolBar.ivAvatar.setImageDrawable(
                     ContextCompat.getDrawable(
                         requireContext(),
                         R.drawable.amity_ic_user
@@ -305,17 +303,19 @@ class AmityChatRoomWithDefaultComposeBarFragment : AmityPickerFragment(),
     }
 
     private fun initToolBar() {
-        if (essentialViewModel.enableChatToolbar) {
-            (activity as AppCompatActivity).supportActionBar?.displayOptions =
-                ActionBar.DISPLAY_SHOW_CUSTOM
-            (activity as AppCompatActivity).setSupportActionBar(chatToolBar as Toolbar)
+        binding.chatToolBar.apply {
+            if (essentialViewModel.enableChatToolbar) {
+                (activity as AppCompatActivity).supportActionBar?.displayOptions =
+                    ActionBar.DISPLAY_SHOW_CUSTOM
+                (activity as AppCompatActivity).setSupportActionBar(root as Toolbar)
 
-            chatToolBar.ivBack.setOnClickListener {
-                activity?.finish()
+                ivBack.setOnClickListener {
+                    activity?.finish()
+                }
+                root.visibility = View.VISIBLE
+            } else {
+                root.visibility = View.GONE
             }
-            chatToolBar.visibility = View.VISIBLE
-        } else {
-            chatToolBar.visibility = View.GONE
         }
     }
 
@@ -329,34 +329,36 @@ class AmityChatRoomWithDefaultComposeBarFragment : AmityPickerFragment(),
             )
         val layoutManager = LinearLayoutManager(activity)
         layoutManager.stackFromEnd = true
-        rvChatList.layoutManager = layoutManager
-        rvChatList.adapter = mAdapter
-        rvChatList.addItemDecoration(
-            AmityRecyclerViewItemDecoration(
-                0,
-                0,
-                resources.getDimensionPixelSize(R.dimen.amity_padding_xs)
+        binding.rvChatList.apply {
+            this.layoutManager = layoutManager
+            adapter = mAdapter
+            addItemDecoration(
+                AmityRecyclerViewItemDecoration(
+                    0,
+                    0,
+                    resources.getDimensionPixelSize(R.dimen.amity_padding_xs)
+                )
             )
-        )
-        rvChatList.itemAnimator = null
-        val percentage = 30F / 100
-        val background = ColorUtils.setAlphaComponent(
-            AmityColorPaletteUtil.getColor(
-                ContextCompat.getColor(
-                    requireContext(),
-                    R.color.amityColorBase
-                ), AmityColorShade.SHADE4
-            ), (percentage * 255).toInt()
-        )
-        rvChatList.setBackgroundColor(background)
-        observeScrollingState(layoutManager)
-        observeMessages()
+            itemAnimator = null
+            val percentage = 30F / 100
+            val background = ColorUtils.setAlphaComponent(
+                AmityColorPaletteUtil.getColor(
+                    ContextCompat.getColor(
+                        requireContext(),
+                        R.color.amityColorBase
+                    ), AmityColorShade.SHADE4
+                ), (percentage * 255).toInt()
+            )
+            setBackgroundColor(background)
+            observeScrollingState(layoutManager)
+            observeMessages()
+        }
     }
 
     private fun observeMessages() {
         messageListDisposable= messageListViewModel.getAllMessages().subscribe { messageList ->
             mAdapter.submitList(messageList)
-            messageListViewModel.isScrollable.set(rvChatList.computeVerticalScrollRange() > rvChatList.height)
+            messageListViewModel.isScrollable.set(binding.rvChatList.computeVerticalScrollRange() > binding.rvChatList.height)
         }
         messageListViewModel.startReading()
     }
@@ -373,13 +375,13 @@ class AmityChatRoomWithDefaultComposeBarFragment : AmityPickerFragment(),
 
     @SuppressLint("ClickableViewAccessibility")
     private fun setRecorderTouchListener() {
-        mBinding.tvRecord.setOnTouchListener { _, event ->
+        binding.tvRecord.setOnTouchListener { _, event ->
             if (isRecorderPermissionGranted()) {
-                mBinding.recorderView.onTouch(event)
+                binding.recorderView.onTouch(event)
                 when (event?.action) {
                     MotionEvent.ACTION_DOWN -> {
                         messageListViewModel.isRecording.set(true)
-                        mBinding.recorderView.circularReveal()
+                        binding.recorderView.circularReveal()
 
                     }
                     MotionEvent.ACTION_UP -> messageListViewModel.isRecording.set(false)
@@ -393,7 +395,7 @@ class AmityChatRoomWithDefaultComposeBarFragment : AmityPickerFragment(),
 
 
     private fun hideLoadingView() {
-        loading_view?.visibility = View.GONE
+        binding.loadingView.visibility = View.GONE
     }
 
 
@@ -413,7 +415,7 @@ class AmityChatRoomWithDefaultComposeBarFragment : AmityPickerFragment(),
     }
 
     private fun scrollToLastPosition() {
-        rvChatList?.scrollToPosition(mAdapter.itemCount - 1)
+        binding.rvChatList?.scrollToPosition(mAdapter.itemCount - 1)
         isReachBottom = true
     }
 
@@ -427,7 +429,7 @@ class AmityChatRoomWithDefaultComposeBarFragment : AmityPickerFragment(),
                     CoroutineScope(Dispatchers.Main).launch {
                         val snackBar =
                             Snackbar.make(
-                                rvChatList,
+                                binding.rvChatList,
                                 R.string.amity_failed_msg,
                                 Snackbar.LENGTH_SHORT
                             )
@@ -445,29 +447,29 @@ class AmityChatRoomWithDefaultComposeBarFragment : AmityPickerFragment(),
     }
 
     private fun showAudioRecordUi() {
-        AmityAndroidUtil.hideKeyboard(layoutParent)
+        AmityAndroidUtil.hideKeyboard(binding.layoutParent)
         messageListViewModel.showComposeBar.set(false)
     }
 
     private fun toggleSoftKeyboard() {
         messageListViewModel.isVoiceMsgUi.set(false)
-        if (AmityAndroidUtil.isSoftKeyboardOpen(layoutParent)) {
-            AmityAndroidUtil.hideKeyboard(layoutParent)
+        if (AmityAndroidUtil.isSoftKeyboardOpen(binding.layoutParent)) {
+            AmityAndroidUtil.hideKeyboard(binding.layoutParent)
             Handler(Looper.getMainLooper()).postDelayed({
                 messageListViewModel.showComposeBar.set(true)
             }, 300)
         } else {
             if (messageListViewModel.showComposeBar.get()) {
                 messageListViewModel.showComposeBar.set(false)
-                etMessage.requestFocus()
-                AmityAndroidUtil.showKeyboard(etMessage)
+                binding.etMessage.requestFocus()
+                AmityAndroidUtil.showKeyboard(binding.etMessage)
             } else {
                 messageListViewModel.showComposeBar.set(true)
             }
         }
 
         if (messageListViewModel.keyboardHeight.get() == 0) {
-            val height = AmityAndroidUtil.getKeyboardHeight(layoutParent)
+            val height = AmityAndroidUtil.getKeyboardHeight(binding.layoutParent)
             if (height != null && height > 0) {
                 messageListViewModel.keyboardHeight.set(height)
             }

--- a/chat/src/main/java/com/amity/socialcloud/uikit/chat/messages/fragment/AmityChatRoomWithTextComposeBarFragment.kt
+++ b/chat/src/main/java/com/amity/socialcloud/uikit/chat/messages/fragment/AmityChatRoomWithTextComposeBarFragment.kt
@@ -49,24 +49,15 @@ import com.google.android.material.snackbar.Snackbar
 import com.zhihu.matisse.Matisse
 import com.zhihu.matisse.MimeType
 import com.zhihu.matisse.engine.impl.GlideEngine
-import io.reactivex.Single
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.Disposable
 import io.reactivex.schedulers.Schedulers
-import kotlinx.android.synthetic.main.amity_chat_bar.view.*
-import kotlinx.android.synthetic.main.amity_fragment_chat_with_text_compose_bar.chatToolBar
-import kotlinx.android.synthetic.main.amity_fragment_chat_with_text_compose_bar.etMessage
-import kotlinx.android.synthetic.main.amity_fragment_chat_with_text_compose_bar.layoutParent
-import kotlinx.android.synthetic.main.amity_fragment_chat_with_text_compose_bar.loading_view
-import kotlinx.android.synthetic.main.amity_fragment_chat_with_text_compose_bar.recordBackground
-import kotlinx.android.synthetic.main.amity_fragment_chat_with_text_compose_bar.rvChatList
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import java.io.File
 import java.lang.IllegalStateException
-import java.util.concurrent.TimeUnit
 
 
 class AmityChatRoomWithTextComposeBarFragment() : AmityPickerFragment(),
@@ -76,7 +67,7 @@ class AmityChatRoomWithTextComposeBarFragment() : AmityPickerFragment(),
     private val messageListViewModel: AmityMessageListViewModel by viewModels()
 
     private lateinit var mAdapter: AmityMessageListAdapter
-    private lateinit var mBinding: AmityFragmentChatWithTextComposeBarBinding
+    private lateinit var binding: AmityFragmentChatWithTextComposeBarBinding
     private var msgSent = false
     private var viewHolderListener: AmityMessageListAdapter.CustomViewHolderListener? = null
     private var messageListDisposable: Disposable? = null
@@ -105,9 +96,9 @@ class AmityChatRoomWithTextComposeBarFragment() : AmityPickerFragment(),
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        mBinding = DataBindingUtil.inflate(inflater, R.layout.amity_fragment_chat_with_text_compose_bar, container, false)
-        mBinding.viewModel = messageListViewModel
-        return mBinding.root
+        binding = DataBindingUtil.inflate(inflater, R.layout.amity_fragment_chat_with_text_compose_bar, container, false)
+        binding.viewModel = messageListViewModel
+        return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -123,19 +114,21 @@ class AmityChatRoomWithTextComposeBarFragment() : AmityPickerFragment(),
     }
 
     private fun setupComposebar() {
-        etMessage.setShape(
-            null, null, null, null,
-            R.color.amityColorBase, R.color.amityColorBase, AmityColorShade.SHADE4
-        )
-        recordBackground.setShape(
-            null, null, null, null,
-            R.color.amityColorBase, R.color.amityColorBase, AmityColorShade.SHADE4
-        )
-        etMessage.setOnClickListener {
-            messageListViewModel.showComposeBar.set(false)
-        }
-        etMessage.setOnFocusChangeListener { _, _ ->
-            messageListViewModel.showComposeBar.set(false)
+        binding.apply {
+            etMessage.setShape(
+                    null, null, null, null,
+                    R.color.amityColorBase, R.color.amityColorBase, AmityColorShade.SHADE4
+            )
+            recordBackground.setShape(
+                    null, null, null, null,
+                    R.color.amityColorBase, R.color.amityColorBase, AmityColorShade.SHADE4
+            )
+            etMessage.setOnClickListener {
+                messageListViewModel.showComposeBar.set(false)
+            }
+            etMessage.setOnFocusChangeListener { _, _ ->
+                messageListViewModel.showComposeBar.set(false)
+            }
         }
     }
 
@@ -166,21 +159,21 @@ class AmityChatRoomWithTextComposeBarFragment() : AmityPickerFragment(),
 
     private fun presentDisconnectedView() {
         if (essentialViewModel.enableConnectionBar) {
-            mBinding.connectionView.visibility = View.VISIBLE
-            mBinding.connectionTexview.setText(R.string.amity_no_internet)
-            mBinding.connectionTexview.setBackgroundColor(resources.getColor(R.color.amityColorGrey))
+            binding.connectionView.visibility = View.VISIBLE
+            binding.connectionTexview.setText(R.string.amity_no_internet)
+            binding.connectionTexview.setBackgroundColor(resources.getColor(R.color.amityColorGrey))
         }
     }
 
     private fun presentReconnectedView() {
         if (essentialViewModel.enableConnectionBar) {
-            mBinding.connectionView.visibility = View.GONE
+            binding.connectionView.visibility = View.GONE
         }
     }
 
     private fun presentChatRefreshLoadingView() {
-        mBinding.loadingView.setBackgroundColor(resources.getColor(R.color.amityTranslucentBackground))
-        mBinding.loadingView.visibility = View.VISIBLE
+        binding.loadingView.setBackgroundColor(resources.getColor(R.color.amityTranslucentBackground))
+        binding.loadingView.visibility = View.VISIBLE
     }
 
     private fun resetMessageLoader() {
@@ -200,11 +193,11 @@ class AmityChatRoomWithTextComposeBarFragment() : AmityPickerFragment(),
     }
 
     override fun onMessageClicked(position: Int) {
-        rvChatList.scrollToPosition(position)
+        binding.rvChatList.scrollToPosition(position)
     }
 
     private fun observeScrollingState(layoutManager: LinearLayoutManager) {
-        rvChatList.addOnScrollListener(object : RecyclerView.OnScrollListener() {
+        binding.rvChatList.addOnScrollListener(object : RecyclerView.OnScrollListener() {
             override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
                 super.onScrolled(recyclerView, dx, dy)
                 val firstVisibleItem = layoutManager.findFirstVisibleItemPosition()
@@ -252,14 +245,14 @@ class AmityChatRoomWithTextComposeBarFragment() : AmityPickerFragment(),
     private fun getChannelType() {
         disposable.add(messageListViewModel.getChannelType().take(1).subscribe { ekoChannel ->
             if (ekoChannel.getType() == AmityChannel.Type.STANDARD) {
-                mBinding.chatToolBar.ivAvatar.setImageDrawable(
+                binding.chatToolBar.ivAvatar.setImageDrawable(
                     ContextCompat.getDrawable(
                         requireContext(),
                         R.drawable.amity_ic_group
                     )
                 )
             } else {
-                mBinding.chatToolBar.ivAvatar.setImageDrawable(
+                binding.chatToolBar.ivAvatar.setImageDrawable(
                     ContextCompat.getDrawable(
                         requireContext(),
                         R.drawable.amity_ic_user
@@ -291,17 +284,19 @@ class AmityChatRoomWithTextComposeBarFragment() : AmityPickerFragment(),
     }
 
     private fun initToolBar() {
-        if (essentialViewModel.enableChatToolbar) {
-            (activity as AppCompatActivity).supportActionBar?.displayOptions =
-                ActionBar.DISPLAY_SHOW_CUSTOM
-            (activity as AppCompatActivity).setSupportActionBar(chatToolBar as Toolbar)
+        binding.chatToolBar.apply {
+            if (essentialViewModel.enableChatToolbar) {
+                (activity as AppCompatActivity).supportActionBar?.displayOptions =
+                        ActionBar.DISPLAY_SHOW_CUSTOM
+                (activity as AppCompatActivity).setSupportActionBar(root as Toolbar)
 
-            chatToolBar.ivBack.setOnClickListener {
-                activity?.finish()
+                ivBack.setOnClickListener {
+                    activity?.finish()
+                }
+                root.visibility = View.VISIBLE
+            } else {
+                root.visibility = View.GONE
             }
-            chatToolBar.visibility = View.VISIBLE
-        } else {
-            chatToolBar.visibility = View.GONE
         }
     }
 
@@ -315,26 +310,28 @@ class AmityChatRoomWithTextComposeBarFragment() : AmityPickerFragment(),
             )
         val layoutManager = LinearLayoutManager(activity)
         layoutManager.stackFromEnd = true
-        rvChatList.layoutManager = layoutManager
-        rvChatList.adapter = mAdapter
-        rvChatList.addItemDecoration(
-            AmityRecyclerViewItemDecoration(
-                0,
-                0,
-                resources.getDimensionPixelSize(R.dimen.amity_padding_xs)
+        binding.rvChatList.apply {
+            this.layoutManager = layoutManager
+            this.adapter = mAdapter
+            this.addItemDecoration(
+                    AmityRecyclerViewItemDecoration(
+                            0,
+                            0,
+                            resources.getDimensionPixelSize(R.dimen.amity_padding_xs)
+                    )
             )
-        )
-        rvChatList.itemAnimator = null
-        val percentage = 30F / 100
-        val background = ColorUtils.setAlphaComponent(
-            AmityColorPaletteUtil.getColor(
-                ContextCompat.getColor(
-                    requireContext(),
-                    R.color.amityColorBase
-                ), AmityColorShade.SHADE4
-            ), (percentage * 255).toInt()
-        )
-        rvChatList.setBackgroundColor(background)
+            this.itemAnimator = null
+            val percentage = 30F / 100
+            val background = ColorUtils.setAlphaComponent(
+                    AmityColorPaletteUtil.getColor(
+                            ContextCompat.getColor(
+                                    requireContext(),
+                                    R.color.amityColorBase
+                            ), AmityColorShade.SHADE4
+                    ), (percentage * 255).toInt()
+            )
+            this.setBackgroundColor(background)
+        }
         observeScrollingState(layoutManager)
         observeMessages()
     }
@@ -342,7 +339,7 @@ class AmityChatRoomWithTextComposeBarFragment() : AmityPickerFragment(),
     private fun observeMessages() {
         messageListDisposable= messageListViewModel.getAllMessages().subscribe { messageList ->
             mAdapter.submitList(messageList)
-            messageListViewModel.isScrollable.set(rvChatList.computeVerticalScrollRange() > rvChatList.height)
+            messageListViewModel.isScrollable.set(binding.rvChatList.computeVerticalScrollRange() > binding.rvChatList.height)
         }
         messageListViewModel.startReading()
     }
@@ -358,11 +355,11 @@ class AmityChatRoomWithTextComposeBarFragment() : AmityPickerFragment(),
     }
 
     private fun hideLoadingView() {
-        loading_view?.visibility = View.GONE
+        binding.loadingView?.visibility = View.GONE
     }
 
     private fun scrollToLastPosition() {
-        rvChatList?.scrollToPosition(mAdapter.itemCount - 1)
+        binding.rvChatList?.scrollToPosition(mAdapter.itemCount - 1)
         isReachBottom = true
     }
 
@@ -376,7 +373,7 @@ class AmityChatRoomWithTextComposeBarFragment() : AmityPickerFragment(),
                     CoroutineScope(Dispatchers.Main).launch {
                         val snackBar =
                             Snackbar.make(
-                                rvChatList,
+                                binding.rvChatList,
                                 R.string.amity_failed_msg,
                                 Snackbar.LENGTH_SHORT
                             )
@@ -394,29 +391,29 @@ class AmityChatRoomWithTextComposeBarFragment() : AmityPickerFragment(),
     }
 
     private fun showAudioRecordUi() {
-        AmityAndroidUtil.hideKeyboard(layoutParent)
+        AmityAndroidUtil.hideKeyboard(binding.layoutParent)
         messageListViewModel.showComposeBar.set(false)
     }
 
     private fun toggleSoftKeyboard() {
         messageListViewModel.isVoiceMsgUi.set(false)
-        if (AmityAndroidUtil.isSoftKeyboardOpen(layoutParent)) {
-            AmityAndroidUtil.hideKeyboard(layoutParent)
+        if (AmityAndroidUtil.isSoftKeyboardOpen(binding.layoutParent)) {
+            AmityAndroidUtil.hideKeyboard(binding.layoutParent)
             Handler(Looper.getMainLooper()).postDelayed({
                 messageListViewModel.showComposeBar.set(true)
             }, 300)
         } else {
             if (messageListViewModel.showComposeBar.get()) {
                 messageListViewModel.showComposeBar.set(false)
-                etMessage.requestFocus()
-                AmityAndroidUtil.showKeyboard(etMessage)
+                binding.etMessage.requestFocus()
+                AmityAndroidUtil.showKeyboard(binding.etMessage)
             } else {
                 messageListViewModel.showComposeBar.set(true)
             }
         }
 
         if (messageListViewModel.keyboardHeight.get() == 0) {
-            val height = AmityAndroidUtil.getKeyboardHeight(layoutParent)
+            val height = AmityAndroidUtil.getKeyboardHeight(binding.layoutParent)
             if (height != null && height > 0) {
                 messageListViewModel.keyboardHeight.set(height)
             }

--- a/chat/src/main/java/com/amity/socialcloud/uikit/chat/recent/fragment/AmityRecentChatFragment.kt
+++ b/chat/src/main/java/com/amity/socialcloud/uikit/chat/recent/fragment/AmityRecentChatFragment.kt
@@ -16,23 +16,22 @@ import com.amity.socialcloud.uikit.chat.messages.AmityMessageListActivity
 import com.amity.socialcloud.uikit.chat.recent.adapter.AmityRecentChatAdapter
 import com.amity.socialcloud.uikit.chat.util.AmityRecentItemDecoration
 import io.reactivex.disposables.Disposable
-import kotlinx.android.synthetic.main.amity_fragment_recent_chat.*
 
 class AmityRecentChatFragment private constructor() : Fragment(), AmityRecentChatItemClickListener {
     private lateinit var mViewModel: AmityRecentChatViewModel
 
     private lateinit var mAdapter: AmityRecentChatAdapter
     private lateinit var recentChatDisposable: Disposable
-    private lateinit var mBinding: AmityFragmentRecentChatBinding
+    private lateinit var binding: AmityFragmentRecentChatBinding
 
     override fun onCreateView(
             inflater: LayoutInflater, container: ViewGroup?,
             savedInstanceState: Bundle?
-    ): View? {
+    ): View {
         mViewModel = ViewModelProvider(requireActivity()).get(AmityRecentChatViewModel::class.java)
-        mBinding =
+        binding =
                 DataBindingUtil.inflate(inflater, R.layout.amity_fragment_recent_chat, container, false)
-        return mBinding.root
+        return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -43,25 +42,27 @@ class AmityRecentChatFragment private constructor() : Fragment(), AmityRecentCha
     private fun initRecyclerView() {
         mAdapter = AmityRecentChatAdapter()
         mAdapter.setCommunityChatItemClickListener(this)
-        rvRecentChat.layoutManager = LinearLayoutManager(requireContext())
-        rvRecentChat.adapter = mAdapter
-        rvRecentChat.addItemDecoration(
-                AmityRecentItemDecoration(
-                        requireContext(),
-                        resources.getDimensionPixelSize(R.dimen.amity_padding_m2)
-                )
-        )
+        binding.rvRecentChat.apply {
+            this.layoutManager = LinearLayoutManager(requireContext())
+            this.adapter = mAdapter
+            this.addItemDecoration(
+                    AmityRecentItemDecoration(
+                            requireContext(),
+                            resources.getDimensionPixelSize(R.dimen.amity_padding_m2)
+                    )
+            )
+        }
         getRecentChatData()
     }
 
     private fun getRecentChatData() {
         recentChatDisposable = mViewModel.getRecentChat().subscribe { chatList ->
             if (chatList.isEmpty()) {
-                emptyView.visibility = View.VISIBLE
-                rvRecentChat.visibility = View.GONE
+                binding.emptyView.visibility = View.VISIBLE
+                binding.rvRecentChat.visibility = View.GONE
             } else {
-                emptyView.visibility = View.GONE
-                rvRecentChat.visibility = View.VISIBLE
+                binding.emptyView.visibility = View.GONE
+                binding.rvRecentChat.visibility = View.VISIBLE
                 mAdapter.submitList(chatList)
             }
         }

--- a/common/src/main/java/com/amity/socialcloud/uikit/common/base/AmityBaseActivity.kt
+++ b/common/src/main/java/com/amity/socialcloud/uikit/common/base/AmityBaseActivity.kt
@@ -21,7 +21,7 @@ import com.trello.rxlifecycle3.components.support.RxAppCompatActivity
 abstract class AmityBaseActivity<T : ViewDataBinding, V : AmityBaseViewModel> :
     RxAppCompatActivity() {
 
-    private lateinit var mViewDataBinding: T
+    protected lateinit var mViewDataBinding: T
     private var mViewModel: V? = null
 
     @LayoutRes

--- a/common/src/main/java/com/amity/socialcloud/uikit/common/base/AmityBaseToolbarFragmentContainerActivity.kt
+++ b/common/src/main/java/com/amity/socialcloud/uikit/common/base/AmityBaseToolbarFragmentContainerActivity.kt
@@ -10,8 +10,6 @@ import com.amity.socialcloud.uikit.common.R
 import com.amity.socialcloud.uikit.common.components.AmityToolBar
 import com.amity.socialcloud.uikit.common.components.AmityToolBarClickListener
 import com.amity.socialcloud.uikit.common.databinding.AmityActivityBaseToolbarFragmentContainerBinding
-import kotlinx.android.synthetic.main.amity_activity_base_toolbar_fragment_container.*
-
 
 abstract class AmityBaseToolbarFragmentContainerActivity : AppCompatActivity(),
         AmityToolBarClickListener {
@@ -28,14 +26,14 @@ abstract class AmityBaseToolbarFragmentContainerActivity : AppCompatActivity(),
         }
 
         supportActionBar?.displayOptions = ActionBar.DISPLAY_SHOW_CUSTOM
-        setSupportActionBar(toolbar)
-        toolbar?.setClickListener(this)
+        setSupportActionBar(binding.toolbar)
+        binding.toolbar?.setClickListener(this)
 
         initToolbar()
     }
 
     fun getToolBar(): AmityToolBar? {
-        return toolbar
+        return binding.toolbar
     }
 
     fun showToolbarDivider() {

--- a/common/src/main/java/com/amity/socialcloud/uikit/common/common/views/avatar/AmityAvatarView.kt
+++ b/common/src/main/java/com/amity/socialcloud/uikit/common/common/views/avatar/AmityAvatarView.kt
@@ -7,15 +7,13 @@ import androidx.annotation.DrawableRes
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.ContextCompat
 import com.amity.socialcloud.uikit.common.R
+import com.amity.socialcloud.uikit.common.databinding.AmityComponentAvatarBinding
 import com.bumptech.glide.Glide
-import kotlinx.android.synthetic.main.amity_component_avatar.view.*
 
 class AmityAvatarView : ConstraintLayout {
     lateinit var style: AmityAvatarViewStyle
 
-    init {
-        LayoutInflater.from(context).inflate(R.layout.amity_component_avatar, this, true)
-    }
+    private val binding: AmityComponentAvatarBinding = AmityComponentAvatarBinding.inflate(LayoutInflater.from(context), this, true)
 
     constructor(context: Context, attrs: AttributeSet, defStyle: Int) : super(
         context,
@@ -51,21 +49,19 @@ class AmityAvatarView : ConstraintLayout {
 
     private fun applyStyle() {
         background = ContextCompat.getDrawable(context, R.drawable.amity_ic_default_ring)
-        image_avatar.layoutParams.height = style.avatarHeight
-        image_avatar.layoutParams.width = style.avatarWidth
+        binding.imageAvatar.layoutParams.height = style.avatarHeight
+        binding.imageAvatar.layoutParams.width = style.avatarWidth
         if (style.avatarDrawable != -1) {
             Glide.with(context).load(style.avatarDrawable)
-                .into(image_avatar)
+                .into(binding.imageAvatar)
         } else if (style.avatarUrl != null) {
             Glide.with(context)
                 .load(style.avatarUrl)
                 .centerCrop()
-                .into(image_avatar)
+                .into(binding.imageAvatar)
         } else {
-            Glide.with(context).load(R.drawable.amity_ic_avatar_placeholder).into(image_avatar)
+            Glide.with(context).load(R.drawable.amity_ic_avatar_placeholder).into(binding.imageAvatar)
         }
-
-
     }
 
 }

--- a/common/src/main/java/com/amity/socialcloud/uikit/common/common/views/bottomsheet/AmityBottomSheetListFragment.kt
+++ b/common/src/main/java/com/amity/socialcloud/uikit/common/common/views/bottomsheet/AmityBottomSheetListFragment.kt
@@ -5,13 +5,15 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.LinearLayoutManager
-import com.amity.socialcloud.uikit.common.R
+import com.amity.socialcloud.uikit.common.databinding.AmityBottomSheetBinding
 import com.amity.socialcloud.uikit.common.model.AmityMenuItem
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
-import kotlinx.android.synthetic.main.amity_bottom_sheet.*
 
 @Deprecated("Use AmityBottomSheetDialog instead")
 class AmityBottomSheetListFragment private constructor() : BottomSheetDialogFragment() {
+
+    private var _binding: AmityBottomSheetBinding? = null
+    private val binding get() = _binding!!
 
     private lateinit var itemList: ArrayList<AmityMenuItem>
     private var mListener: AmityMenuItemClickListener? = null
@@ -37,19 +39,25 @@ class AmityBottomSheetListFragment private constructor() : BottomSheetDialogFrag
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        return inflater.inflate(R.layout.amity_bottom_sheet, container, false)
+        _binding = AmityBottomSheetBinding.inflate(inflater, container, false)
+        return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
         mAdapter = AmityBottomSheetAdapter(itemList, mListener)
-        rvBottomSheet.layoutManager = LinearLayoutManager(requireContext())
-        rvBottomSheet.adapter = mAdapter
+        binding.rvBottomSheet.layoutManager = LinearLayoutManager(requireContext())
+        binding.rvBottomSheet.adapter = mAdapter
     }
 
     fun setMenuItemClickListener(listener: AmityMenuItemClickListener) {
         mListener = listener
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
 }

--- a/common/src/main/java/com/amity/socialcloud/uikit/common/common/views/dialog/AmityBottomSheetDialogFragment.kt
+++ b/common/src/main/java/com/amity/socialcloud/uikit/common/common/views/dialog/AmityBottomSheetDialogFragment.kt
@@ -3,19 +3,21 @@ package com.amity.socialcloud.uikit.common.common.views.dialog
 import android.os.Bundle
 import android.view.*
 import androidx.annotation.MenuRes
-import com.amity.socialcloud.uikit.common.R
+import com.amity.socialcloud.uikit.common.databinding.AmityDialogBottomSheetBinding
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
-import kotlinx.android.synthetic.main.amity_dialog_bottom_sheet.*
 import kotlin.properties.Delegates
-
 
 const val EXTRA_PARAM_NAV_MENU = "nav_menu"
 
 @Deprecated("Use AmityBottomSheetDialog instead")
 class AmityBottomSheetDialogFragment private constructor() : BottomSheetDialogFragment() {
+    private var _binding: AmityDialogBottomSheetBinding? = null
+    private val binding get() = _binding!!
+
     private var navListener: OnNavigationItemSelectedListener? = null
     var menu by Delegates.notNull<Int>()
     private var menuItemCallback: (Menu) -> Unit = {}
+
 
     companion object {
         fun newInstance(@MenuRes menu: Int): AmityBottomSheetDialogFragment {
@@ -34,7 +36,8 @@ class AmityBottomSheetDialogFragment private constructor() : BottomSheetDialogFr
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        return inflater.inflate(R.layout.amity_dialog_bottom_sheet, container, false)
+        _binding = AmityDialogBottomSheetBinding.inflate(inflater, container, false)
+        return binding.root
     }
 
     fun setOnNavigationItemSelectedListener(listener: OnNavigationItemSelectedListener) {
@@ -43,13 +46,15 @@ class AmityBottomSheetDialogFragment private constructor() : BottomSheetDialogFr
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        navigationView.menu.clear()
-        navigationView.inflateMenu(menu)
-        menuItemCallback.invoke(navigationView.menu)
-        navigationView.setNavigationItemSelectedListener { item ->
-            navListener?.onItemSelected(item)
-            dismiss()
-            true
+        binding.navigationView.apply {
+            menu.clear()
+            inflateMenu(this@AmityBottomSheetDialogFragment.menu)
+            menuItemCallback.invoke(menu)
+            setNavigationItemSelectedListener { item ->
+                navListener?.onItemSelected(item)
+                dismiss()
+                true
+            }
         }
 
     }
@@ -60,6 +65,11 @@ class AmityBottomSheetDialogFragment private constructor() : BottomSheetDialogFr
 
     interface OnNavigationItemSelectedListener {
         fun onItemSelected(item: MenuItem)
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
 }

--- a/common/src/main/java/com/amity/socialcloud/uikit/common/common/views/dialog/bottomsheet/AmityBottomSheetDialog.kt
+++ b/common/src/main/java/com/amity/socialcloud/uikit/common/common/views/dialog/bottomsheet/AmityBottomSheetDialog.kt
@@ -3,21 +3,22 @@ package com.amity.socialcloud.uikit.common.common.views.dialog.bottomsheet
 import android.content.Context
 import android.view.LayoutInflater
 import androidx.recyclerview.widget.LinearLayoutManager
-import com.amity.socialcloud.uikit.common.R
+import com.amity.socialcloud.uikit.common.databinding.AmityBottomSheetMenuBinding
 import com.google.android.material.bottomsheet.BottomSheetDialog
-import kotlinx.android.synthetic.main.amity_bottom_sheet_menu.view.*
 
 class AmityBottomSheetDialog(context: Context, items: List<BottomSheetMenuItem>? = listOf()) {
 
+    private var _binding: AmityBottomSheetMenuBinding? = null
+    private val binding get() = _binding!!
     private val bottomSheetDialog: BottomSheetDialog = BottomSheetDialog(context)
     private val adapter = BottomSheetMenuAdapter(items ?: listOf())
 
     init {
-        val view = LayoutInflater.from(context).inflate(R.layout.amity_bottom_sheet_menu, null)
-        bottomSheetDialog.setContentView(view)
-        with(view) {
-            bottom_sheet_recyclerview.layoutManager = LinearLayoutManager(context)
-            bottom_sheet_recyclerview.adapter = adapter
+        _binding = AmityBottomSheetMenuBinding.inflate(LayoutInflater.from(context), null, false)
+        bottomSheetDialog.setContentView(binding.root)
+        with(binding.root) {
+            layoutManager = LinearLayoutManager(context)
+            this.adapter = adapter
         }
     }
 
@@ -33,5 +34,4 @@ class AmityBottomSheetDialog(context: Context, items: List<BottomSheetMenuItem>?
     fun dismiss() {
         bottomSheetDialog.dismiss()
     }
-
 }

--- a/common/src/main/java/com/amity/socialcloud/uikit/common/common/views/dialog/bottomsheet/AmityBottomSheetDialog.kt
+++ b/common/src/main/java/com/amity/socialcloud/uikit/common/common/views/dialog/bottomsheet/AmityBottomSheetDialog.kt
@@ -3,22 +3,22 @@ package com.amity.socialcloud.uikit.common.common.views.dialog.bottomsheet
 import android.content.Context
 import android.view.LayoutInflater
 import androidx.recyclerview.widget.LinearLayoutManager
-import com.amity.socialcloud.uikit.common.databinding.AmityBottomSheetMenuBinding
+import androidx.recyclerview.widget.RecyclerView
+import com.amity.socialcloud.uikit.common.R
 import com.google.android.material.bottomsheet.BottomSheetDialog
 
 class AmityBottomSheetDialog(context: Context, items: List<BottomSheetMenuItem>? = listOf()) {
 
-    private var _binding: AmityBottomSheetMenuBinding? = null
-    private val binding get() = _binding!!
     private val bottomSheetDialog: BottomSheetDialog = BottomSheetDialog(context)
     private val adapter = BottomSheetMenuAdapter(items ?: listOf())
 
     init {
-        _binding = AmityBottomSheetMenuBinding.inflate(LayoutInflater.from(context), null, false)
-        bottomSheetDialog.setContentView(binding.root)
-        with(binding.root) {
-            layoutManager = LinearLayoutManager(context)
-            this.adapter = adapter
+        val view =
+            LayoutInflater.from(context).inflate(R.layout.amity_bottom_sheet_menu, null, false)
+        bottomSheetDialog.setContentView(view)
+        (view.findViewById<RecyclerView>(R.id.bottom_sheet_recyclerview))?.let {
+            it.layoutManager = LinearLayoutManager(context)
+            it.adapter = adapter
         }
     }
 
@@ -34,4 +34,5 @@ class AmityBottomSheetDialog(context: Context, items: List<BottomSheetMenuItem>?
     fun dismiss() {
         bottomSheetDialog.dismiss()
     }
+
 }

--- a/common/src/main/java/com/amity/socialcloud/uikit/common/common/views/dialog/bottomsheet/BottomSheetMenuAdapter.kt
+++ b/common/src/main/java/com/amity/socialcloud/uikit/common/common/views/dialog/bottomsheet/BottomSheetMenuAdapter.kt
@@ -5,12 +5,12 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.amity.socialcloud.uikit.common.R
-import kotlinx.android.synthetic.main.amity_item_bottom_sheet_menu.view.*
+import com.amity.socialcloud.uikit.common.databinding.AmityItemBottomSheetMenuBinding
 
 class BottomSheetMenuAdapter(private var items: List<BottomSheetMenuItem>) : RecyclerView.Adapter<BottomSheetMenuAdapter.BottomSheetMenuViewHolder>() {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): BottomSheetMenuViewHolder {
-        return BottomSheetMenuViewHolder(LayoutInflater.from(parent.context).inflate(R.layout.amity_item_bottom_sheet_menu, parent, false))
+        return BottomSheetMenuViewHolder(AmityItemBottomSheetMenuBinding.inflate(LayoutInflater.from(parent.context), parent, false))
     }
 
     override fun getItemCount(): Int = items.size
@@ -19,23 +19,23 @@ class BottomSheetMenuAdapter(private var items: List<BottomSheetMenuItem>) : Rec
         holder.bind(items[position])
     }
 
-    class BottomSheetMenuViewHolder(val view: View) : RecyclerView.ViewHolder(view) {
+    class BottomSheetMenuViewHolder(val binding: AmityItemBottomSheetMenuBinding) : RecyclerView.ViewHolder(binding.root) {
 
         fun bind(item: BottomSheetMenuItem) {
-            with(view) {
-                bottom_menu_title.text = view.resources.getString(item.titleResId)
+            with(binding) {
+                bottomMenuTitle.text = itemView.resources.getString(item.titleResId)
                 if(item.iconResId != null) {
-                    bottom_menu_icon.setImageResource(item.iconResId)
-                    bottom_menu_icon.visibility = View.VISIBLE
+                    bottomMenuIcon.setImageResource(item.iconResId)
+                    bottomMenuIcon.visibility = View.VISIBLE
                 } else {
-                    bottom_menu_icon.visibility = View.GONE
+                    bottomMenuIcon.visibility = View.GONE
                 }
                 if (item.colorResId != null) {
-                    bottom_menu_title.setTextColor(context.resources.getColor(item.colorResId))
+                    bottomMenuTitle.setTextColor(itemView.resources.getColor(item.colorResId))
                 } else {
-                    bottom_menu_title.setTextColor(context.resources.getColor(R.color.amityColorBlack))
+                    bottomMenuTitle.setTextColor(itemView.resources.getColor(R.color.amityColorBlack))
                 }
-                setOnClickListener { item.action() }
+                root.setOnClickListener { item.action() }
             }
         }
     }

--- a/common/src/main/java/com/amity/socialcloud/uikit/common/components/AmityToolBar.kt
+++ b/common/src/main/java/com/amity/socialcloud/uikit/common/components/AmityToolBar.kt
@@ -14,11 +14,10 @@ import com.amity.socialcloud.uikit.common.common.views.AmityColorPaletteUtil
 import com.amity.socialcloud.uikit.common.common.views.AmityColorShade
 import com.amity.socialcloud.uikit.common.databinding.AmityToolbarBinding
 import com.google.android.material.appbar.MaterialToolbar
-import kotlinx.android.synthetic.main.amity_toolbar.view.*
 
 class AmityToolBar : MaterialToolbar {
 
-    private lateinit var mBinding: AmityToolbarBinding
+    private lateinit var binding: AmityToolbarBinding
 
     constructor(context: Context) : super(context) {
         init()
@@ -38,8 +37,8 @@ class AmityToolBar : MaterialToolbar {
 
     private fun init() {
         val inflater = context.getSystemService(Context.LAYOUT_INFLATER_SERVICE) as LayoutInflater
-        mBinding = DataBindingUtil.inflate(inflater, R.layout.amity_toolbar, this, true)
-        mBinding.rightStringActive = false
+        binding = DataBindingUtil.inflate(inflater, R.layout.amity_toolbar, this, true)
+        binding.rightStringActive = false
         toggleRightTextColor(false)
         setContentInsetsRelative(0, 0)
         setUpImageViewLeft()
@@ -47,61 +46,62 @@ class AmityToolBar : MaterialToolbar {
     }
 
     private fun setUpImageViewLeft() {
-        ivLeft.expandViewHitArea()
+        binding.ivLeft.expandViewHitArea()
     }
 
     private fun setUpImageViewRight() {
-        tv_right.expandViewHitArea()
+        binding.tvRight.expandViewHitArea()
     }
 
     fun setLeftString(value: String) {
-        mBinding.leftString = value
+        binding.leftString = value
     }
 
     fun setLeftDrawable(value: Drawable?, color: Int? = null) {
-        mBinding.leftDrawable = value
-        if (color != null && mBinding.leftDrawable != null) {
-            mBinding.leftDrawable!!.colorFilter =
+        binding.leftDrawable = value
+        if (color != null && binding.leftDrawable != null) {
+            binding.leftDrawable!!.colorFilter =
                 PorterDuffColorFilter(color, PorterDuff.Mode.SRC_IN)
         }
 
     }
 
     fun setRightString(value: String) {
-        mBinding.rightString = value
+        binding.rightString = value
     }
 
     fun setRightStringActive(value: Boolean) {
-        mBinding.rightStringActive = value
+        binding.rightStringActive = value
         toggleRightTextColor(value)
     }
 
     private fun toggleRightTextColor(value: Boolean) {
         if (value) {
-            tv_right.setTextColor(
+            binding.tvRight.setTextColor(
                 AmityColorPaletteUtil.getColor(
                     ContextCompat.getColor(context, R.color.amityColorHighlight),
                     AmityColorShade.DEFAULT
                 )
             )
         } else {
-            tv_right.setTextColor(
+            binding.tvRight.setTextColor(
                 AmityColorPaletteUtil.getColor(
-                    ContextCompat.getColor(context, R.color.amityColorHighlight), AmityColorShade.SHADE2
+                    ContextCompat.getColor(context, R.color.amityColorHighlight),
+                    AmityColorShade.SHADE2
                 )
             )
         }
     }
 
     fun setRightDrawable(value: Drawable?, color: Int? = null) {
-        mBinding.rightDrawable = value
-        if (color != null && mBinding.rightDrawable != null) {
-            mBinding.rightDrawable!!.colorFilter =
+        binding.rightDrawable = value
+        if (color != null && binding.rightDrawable != null) {
+            binding.rightDrawable!!.colorFilter =
                 PorterDuffColorFilter(color, PorterDuff.Mode.SRC_IN)
         }
     }
 
     fun setClickListener(listener: AmityToolBarClickListener) {
-        mBinding.clickListener = listener
+        binding.clickListener = listener
     }
 }

--- a/common/src/main/java/com/amity/socialcloud/uikit/common/imagepreview/AmityImagePreviewActivity.kt
+++ b/common/src/main/java/com/amity/socialcloud/uikit/common/imagepreview/AmityImagePreviewActivity.kt
@@ -8,9 +8,12 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import androidx.viewpager2.widget.ViewPager2
 import com.amity.socialcloud.uikit.common.R
-import kotlinx.android.synthetic.main.amity_activity_image_preview.*
+import com.amity.socialcloud.uikit.common.databinding.AmityActivityImagePreviewBinding
 
 class AmityImagePreviewActivity : AppCompatActivity() {
+    private val binding: AmityActivityImagePreviewBinding by lazy {
+        AmityActivityImagePreviewBinding.inflate(layoutInflater)
+    }
     private lateinit var amityImages: List<AmityPreviewImage>
     private var imagePosition: Int = 0
     private var showImageCount = true
@@ -40,7 +43,7 @@ class AmityImagePreviewActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         window.statusBarColor = ContextCompat.getColor(this, R.color.amityColorSecondary);
 
-        setContentView(R.layout.amity_activity_image_preview)
+        setContentView(binding.root)
         amityImages = intent.getParcelableArrayListExtra(EXTRA_IMAGES) ?: listOf()
         showImageCount = intent.getBooleanExtra(EXTRA_SHOW_IMAGE_COUNT, true)
         imagePosition = intent.getIntExtra(EXTRA_IMAGE_POSITION, 0)
@@ -59,25 +62,25 @@ class AmityImagePreviewActivity : AppCompatActivity() {
                 setToolbarTitle(position)
             }
         }
-        imageViewPages.adapter = imagePreviewAdapter
+        binding.imageViewPages.adapter = imagePreviewAdapter
         imagePreviewAdapter.setItems(amityImages)
-        imageViewPages.setCurrentItem(imagePosition, false)
+        binding.imageViewPages.setCurrentItem(imagePosition, false)
         setToolbarTitle(imagePosition)
 
     }
 
     override fun onResume() {
         super.onResume()
-        imageViewPages.registerOnPageChangeCallback(pageChangeCallback)
+        binding.imageViewPages.registerOnPageChangeCallback(pageChangeCallback)
     }
 
     override fun onPause() {
         super.onPause()
-        imageViewPages.unregisterOnPageChangeCallback(pageChangeCallback)
+        binding.imageViewPages.unregisterOnPageChangeCallback(pageChangeCallback)
     }
 
     private fun initToolbar() {
-        setSupportActionBar(toolbar)
+        setSupportActionBar(binding.toolbar)
         supportActionBar?.setHomeAsUpIndicator(R.drawable.amity_ic_close)
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
         supportActionBar?.setDisplayHomeAsUpEnabled(true)

--- a/common/src/main/java/com/amity/socialcloud/uikit/common/imagepreview/AmityPreviewImage.kt
+++ b/common/src/main/java/com/amity/socialcloud/uikit/common/imagepreview/AmityPreviewImage.kt
@@ -1,7 +1,7 @@
 package com.amity.socialcloud.uikit.common.imagepreview
 
 import android.os.Parcelable
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class AmityPreviewImage(val url: String) : Parcelable

--- a/common/src/main/java/com/amity/socialcloud/uikit/common/model/AmityMenuItem.kt
+++ b/common/src/main/java/com/amity/socialcloud/uikit/common/model/AmityMenuItem.kt
@@ -1,7 +1,7 @@
 package com.amity.socialcloud.uikit.common.model
 
 import android.os.Parcelable
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class AmityMenuItem(

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
+apply plugin: 'kotlin-parcelize'
 apply plugin: 'kotlin-kapt'
 apply plugin: 'com.google.gms.google-services'
 

--- a/sample/src/main/java/com/amity/socialcloud/uikit/sample/AmityFeatureListActivity.kt
+++ b/sample/src/main/java/com/amity/socialcloud/uikit/sample/AmityFeatureListActivity.kt
@@ -14,44 +14,66 @@ import com.amity.socialcloud.uikit.chat.messages.AmityMessageListActivity
 import com.amity.socialcloud.uikit.community.home.activity.AmityCommunityHomePageActivity
 import com.amity.socialcloud.uikit.community.newsfeed.activity.AmityCustomPostRankingFeedActivity
 import com.amity.socialcloud.uikit.community.utils.AmityCommunityNavigation
+import com.amity.socialcloud.uikit.sample.databinding.AmityActivityFeatureListBinding
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.schedulers.Schedulers
-import kotlinx.android.synthetic.main.amity_activity_feature_list.*
 
 class AmityFeatureListActivity : AppCompatActivity() {
+
+    private val binding: AmityActivityFeatureListBinding by lazy {
+        AmityActivityFeatureListBinding.inflate(layoutInflater)
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.amity_activity_feature_list)
-        communityHome.setOnClickListener {
-            val communityIntent = Intent(this, AmityCommunityHomePageActivity::class.java)
-            startActivity(communityIntent)
-        }
+        setContentView(binding.root)
+        binding.apply {
+            communityHome.setOnClickListener {
+                val communityIntent = Intent(
+                    this@AmityFeatureListActivity,
+                    AmityCommunityHomePageActivity::class.java
+                )
+                startActivity(communityIntent)
+            }
 
-        customRankingFeed.setOnClickListener {
-            val communityIntent = Intent(this, AmityCustomPostRankingFeedActivity::class.java)
-            startActivity(communityIntent)
-        }
+            customRankingFeed.setOnClickListener {
+                val communityIntent = Intent(
+                    this@AmityFeatureListActivity,
+                    AmityCustomPostRankingFeedActivity::class.java
+                )
+                startActivity(communityIntent)
+            }
 
-        chatHome.setOnClickListener {
-            val chatIntent = Intent(this, AmityChatHomePageActivity::class.java)
-            startActivity(chatIntent)
-        }
+            chatHome.setOnClickListener {
+                val chatIntent =
+                    Intent(this@AmityFeatureListActivity, AmityChatHomePageActivity::class.java)
+                startActivity(chatIntent)
+            }
 
-        userProfile.setOnClickListener {
-            AmityCommunityNavigation.navigateToUserProfile(this, AmityCoreClient.getUserId())
-        }
+            userProfile.setOnClickListener {
+                AmityCommunityNavigation.navigateToUserProfile(
+                    this@AmityFeatureListActivity,
+                    AmityCoreClient.getUserId()
+                )
+            }
 
-        textComposebar.setOnClickListener {
-            presentJoinDialog(callback = {d, input ->
-                run {
-                    val channelId = input.toString()
-                    joinChannel(channelId)
-                }
-            })
-        }
+            textComposebar.setOnClickListener {
+                presentJoinDialog(callback = { d, input ->
+                    run {
+                        val channelId = input.toString()
+                        joinChannel(channelId)
+                    }
+                })
+            }
 
-        customPostCreation.setOnClickListener {
-            startActivity(Intent(this, AmityPostCreatorSettingsActivity::class.java))
+            customPostCreation.setOnClickListener {
+                startActivity(
+                    Intent(
+                        this@AmityFeatureListActivity,
+                        AmityPostCreatorSettingsActivity::class.java
+                    )
+                )
+            }
         }
     }
 

--- a/sample/src/main/java/com/amity/socialcloud/uikit/sample/AmitySettingActivity.kt
+++ b/sample/src/main/java/com/amity/socialcloud/uikit/sample/AmitySettingActivity.kt
@@ -17,7 +17,7 @@ class AmitySettingActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         AmityThemeUtil.setCurrentTheme(this)
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.amity_activity_setting)
+        setContentView(binding.root)
 
         binding.btnConfirm.setOnClickListener {
             setTheme()

--- a/sample/src/main/java/com/amity/socialcloud/uikit/sample/AmitySettingActivity.kt
+++ b/sample/src/main/java/com/amity/socialcloud/uikit/sample/AmitySettingActivity.kt
@@ -7,19 +7,23 @@ import androidx.appcompat.app.AppCompatActivity
 import com.amity.socialcloud.sdk.AmityCoreClient
 import com.amity.socialcloud.uikit.common.utils.AmityConstants
 import com.amity.socialcloud.uikit.common.utils.AmityThemeUtil
-import kotlinx.android.synthetic.main.amity_activity_setting.*
+import com.amity.socialcloud.uikit.sample.databinding.AmityActivitySettingBinding
 
 class AmitySettingActivity : AppCompatActivity() {
+
+    private val binding: AmityActivitySettingBinding by lazy {
+        AmityActivitySettingBinding.inflate(layoutInflater)
+    }
     override fun onCreate(savedInstanceState: Bundle?) {
         AmityThemeUtil.setCurrentTheme(this)
         super.onCreate(savedInstanceState)
         setContentView(R.layout.amity_activity_setting)
 
-        btnConfirm.setOnClickListener {
+        binding.btnConfirm.setOnClickListener {
             setTheme()
         }
 
-        btnLogout.setOnClickListener {
+        binding.btnLogout.setOnClickListener {
             val sharedPref = getSharedPreferences(AmityConstants.PREF_NAME, Context.MODE_PRIVATE)
             sharedPref?.edit()?.clear()?.apply()
             AmityCoreClient.unregisterDeviceForPushNotification(AmityCoreClient.getUserId()).subscribe()
@@ -30,12 +34,12 @@ class AmitySettingActivity : AppCompatActivity() {
     }
 
     private fun setTheme() {
-        val selectedId = rgTheme.checkedRadioButtonId
+        val selectedId = binding.rgTheme.checkedRadioButtonId
         val sharedPref = this.getSharedPreferences("AMITY_PREF", Context.MODE_PRIVATE)
         with(sharedPref.edit()) {
-            if (selectedId == theme1.id) {
+            if (selectedId == binding.theme1.id) {
                 putInt("THEME", 1)
-            } else if (selectedId == theme2.id) {
+            } else if (selectedId == binding.theme2.id) {
                 putInt("THEME", 2)
             }
             commit()

--- a/sample/src/main/java/com/amity/socialcloud/uikit/sample/MainActivity.kt
+++ b/sample/src/main/java/com/amity/socialcloud/uikit/sample/MainActivity.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.view.View
 import com.amity.socialcloud.sdk.AmityCoreClient
 import com.amity.socialcloud.uikit.common.common.showSnackBar
+import com.amity.socialcloud.uikit.sample.databinding.AmityActivityMainBinding
 import com.amity.socialcloud.uikit.sample.env.Environment
 import com.amity.socialcloud.uikit.sample.env.EnvironmentActivity
 import com.amity.socialcloud.uikit.sample.env.SamplePreferences
@@ -13,11 +14,14 @@ import com.google.android.material.snackbar.Snackbar
 import com.trello.rxlifecycle3.components.support.RxAppCompatActivity
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.schedulers.Schedulers
-import kotlinx.android.synthetic.main.amity_activity_main.*
 import timber.log.Timber
 
 
 class MainActivity : RxAppCompatActivity() {
+
+    private val binding: AmityActivityMainBinding by lazy {
+        AmityActivityMainBinding.inflate(layoutInflater)
+    }
 
     private val changeEnvContract = registerForActivityResult(
         EnvironmentActivity.ChangeEnvironmentContract()
@@ -37,26 +41,28 @@ class MainActivity : RxAppCompatActivity() {
             registerDevice(userId)
         }
 
-        setContentView(R.layout.amity_activity_main)
+        setContentView(binding.root)
 
-        btnLogin.setOnClickListener {
-            if (etUserId.text.isNotEmpty() && etUserName.text.isNotEmpty()) {
-                registerDevice(etUserId.text.toString().trim(), etUserName.text.toString().trim())
-            } else {
-                findViewById<View>(android.R.id.content).showSnackBar(
-                    "Enter userId and Display Name",
-                    Snackbar.LENGTH_SHORT
-                )
+        binding.apply {
+            btnLogin.setOnClickListener {
+                if (etUserId.text.isNotEmpty() && etUserName.text.isNotEmpty()) {
+                    registerDevice(etUserId.text.toString().trim(), etUserName.text.toString().trim())
+                } else {
+                    findViewById<View>(android.R.id.content).showSnackBar(
+                        "Enter userId and Display Name",
+                        Snackbar.LENGTH_SHORT
+                    )
+                }
             }
-        }
 
-        btnEnv.setOnClickListener {
-            val env = Environment(
-                SamplePreferences.getApiKey().get(),
-                SamplePreferences.getHttpUrl().get(),
-                SamplePreferences.getSocketUrl().get()
-            )
-            changeEnvContract.launch(env)
+            btnEnv.setOnClickListener {
+                val env = Environment(
+                    SamplePreferences.getApiKey().get(),
+                    SamplePreferences.getHttpUrl().get(),
+                    SamplePreferences.getSocketUrl().get()
+                )
+                changeEnvContract.launch(env)
+            }
         }
     }
 

--- a/sample/src/main/java/com/amity/socialcloud/uikit/sample/TestActivity.kt
+++ b/sample/src/main/java/com/amity/socialcloud/uikit/sample/TestActivity.kt
@@ -7,26 +7,31 @@ import androidx.appcompat.app.ActionBar
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import com.amity.socialcloud.uikit.community.home.fragments.AmityCommunityHomePageFragment
-import kotlinx.android.synthetic.main.amity_activity_test.*
+import com.amity.socialcloud.uikit.sample.databinding.AmityActivityTestBinding
 
 class TestActivity : AppCompatActivity() {
+
+    private val binding: AmityActivityTestBinding by lazy {
+        AmityActivityTestBinding.inflate(layoutInflater)
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.amity_activity_test)
+        setContentView(binding.root)
         setupToolbar()
         initializeFragment()
     }
 
     private fun setupToolbar() {
-        mToolbar.setLeftDrawable(
+        binding.mToolbar.setLeftDrawable(
             ContextCompat.getDrawable(
                 this,
                 com.amity.socialcloud.uikit.community.R.drawable.amity_ic_arrow_back
             )
         )
-        mToolbar.setLeftString("Test Activity")
+        binding.mToolbar.setLeftString("Test Activity")
         supportActionBar?.displayOptions = ActionBar.DISPLAY_SHOW_CUSTOM
-        setSupportActionBar(mToolbar)
+        setSupportActionBar(binding.mToolbar)
     }
 
     override fun onCreateOptionsMenu(menu: Menu?): Boolean {

--- a/sample/src/main/java/com/amity/socialcloud/uikit/sample/env/Environment.kt
+++ b/sample/src/main/java/com/amity/socialcloud/uikit/sample/env/Environment.kt
@@ -1,7 +1,7 @@
 package com.amity.socialcloud.uikit.sample.env
 
 import android.os.Parcelable
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class Environment(

--- a/sample/src/main/java/com/amity/socialcloud/uikit/sample/env/EnvironmentActivity.kt
+++ b/sample/src/main/java/com/amity/socialcloud/uikit/sample/env/EnvironmentActivity.kt
@@ -12,25 +12,29 @@ import androidx.activity.result.contract.ActivityResultContract
 import com.amity.socialcloud.sdk.AmityCoreClient
 import com.amity.socialcloud.sdk.AmityRegionalEndpoint
 import com.amity.socialcloud.uikit.sample.R
+import com.amity.socialcloud.uikit.sample.databinding.ActivityEnvironmentBinding
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.Disposable
 import io.reactivex.schedulers.Schedulers
-import kotlinx.android.synthetic.main.activity_environment.*
 
 class EnvironmentActivity : AppCompatActivity() {
+
+    private val binding: ActivityEnvironmentBinding by lazy {
+        ActivityEnvironmentBinding.inflate(layoutInflater)
+    }
 
     private var disposable: Disposable? = null
     private lateinit var environment: Environment
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_environment)
+        setContentView(binding.root)
         environment = intent.getParcelableExtra(ChangeEnvironmentContract.EXTRA_ENV)!!
         getCurrentEnvironment()
 
-        btnSubmit.setOnClickListener {
-            val newApiKey = etApiKey.text.toString()
-            val newUrl = etUrl.text.toString()
+        binding.btnSubmit.setOnClickListener {
+            val newApiKey = binding.etApiKey.text.toString()
+            val newUrl = binding.etUrl.text.toString()
             if (newApiKey.isEmpty() || newUrl.isEmpty()) {
                 Toast.makeText(this, "Api key or URL can not be blank", Toast.LENGTH_SHORT).show()
             }else {
@@ -40,30 +44,32 @@ class EnvironmentActivity : AppCompatActivity() {
     }
 
     private fun getCurrentEnvironment() {
-        when (getCurrentOption()) {
-            R.id.radioDev -> {
-                environmentGroup.check(R.id.radioDev)
-                setDefaultValues(R.id.radioDev)
-            }
-            R.id.radioStaging -> {
-                environmentGroup.check(R.id.radioStaging)
-                setDefaultValues(R.id.radioStaging)
-            }
-            R.id.radioProduction -> {
-                environmentGroup.check(R.id.radioProduction)
-                setDefaultValues(R.id.radioProduction)
-            }
-            R.id.radioEU -> {
-                environmentGroup.check(R.id.radioEU)
-                setDefaultValues(R.id.radioEU)
-            }
-            R.id.radioUS -> {
-                environmentGroup.check(R.id.radioUS)
-                setDefaultValues(R.id.radioUS)
-            }
-            else -> {
-                environmentGroup.check(R.id.radioCustom)
-                setDefaultValues(R.id.radioCustom)
+        binding.environmentGroup.apply {
+            when (getCurrentOption()) {
+                R.id.radioDev -> {
+                    check(R.id.radioDev)
+                    setDefaultValues(R.id.radioDev)
+                }
+                R.id.radioStaging -> {
+                    check(R.id.radioStaging)
+                    setDefaultValues(R.id.radioStaging)
+                }
+                R.id.radioProduction -> {
+                    check(R.id.radioProduction)
+                    setDefaultValues(R.id.radioProduction)
+                }
+                R.id.radioEU -> {
+                    check(R.id.radioEU)
+                    setDefaultValues(R.id.radioEU)
+                }
+                R.id.radioUS -> {
+                    check(R.id.radioUS)
+                    setDefaultValues(R.id.radioUS)
+                }
+                else -> {
+                    check(R.id.radioCustom)
+                    setDefaultValues(R.id.radioCustom)
+                }
             }
         }
     }
@@ -124,8 +130,8 @@ class EnvironmentActivity : AppCompatActivity() {
                 url = environment.httpUrl
             }
         }
-        etApiKey.setText(apiKey)
-        etUrl.setText(url)
+        binding.etApiKey.setText(apiKey)
+        binding.etUrl.setText(url)
     }
 
     private fun updatePreference(apiKey: String, url: String) {

--- a/social/src/main/java/com/amity/socialcloud/uikit/community/data/AmitySelectCategoryItem.kt
+++ b/social/src/main/java/com/amity/socialcloud/uikit/community/data/AmitySelectCategoryItem.kt
@@ -1,7 +1,7 @@
 package com.amity.socialcloud.uikit.community.data
 
 import android.os.Parcelable
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class AmitySelectCategoryItem(

--- a/social/src/main/java/com/amity/socialcloud/uikit/community/data/AmitySelectMemberItem.kt
+++ b/social/src/main/java/com/amity/socialcloud/uikit/community/data/AmitySelectMemberItem.kt
@@ -1,7 +1,7 @@
 package com.amity.socialcloud.uikit.community.data
 
 import android.os.Parcelable
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 /**
  * Model class to handle Select Members

--- a/social/src/main/java/com/amity/socialcloud/uikit/community/detailpage/AmityCommunityPageFragment.kt
+++ b/social/src/main/java/com/amity/socialcloud/uikit/community/detailpage/AmityCommunityPageFragment.kt
@@ -33,11 +33,10 @@ import com.google.android.material.appbar.AppBarLayout
 import com.trello.rxlifecycle3.components.support.RxFragment
 import io.reactivex.BackpressureStrategy
 import io.reactivex.subjects.PublishSubject
-import kotlinx.android.synthetic.main.amity_fragment_community_page.*
-
 
 class AmityCommunityPageFragment : RxFragment(),
     AppBarLayout.OnOffsetChangedListener {
+
     private var isCreateCommunity: Boolean = false
 
     private val TAG = AmityCommunityPageFragment::class.java.canonicalName
@@ -111,16 +110,16 @@ class AmityCommunityPageFragment : RxFragment(),
 
     override fun onPause() {
         super.onPause()
-        appBar.removeOnOffsetChangedListener(this)
+        binding.appBar.removeOnOffsetChangedListener(this)
     }
 
     override fun onResume() {
         super.onResume()
-        appBar.addOnOffsetChangedListener(this)
+        binding.appBar.addOnOffsetChangedListener(this)
     }
 
     override fun onOffsetChanged(appBarLayout: AppBarLayout?, verticalOffset: Int) {
-        refreshLayout.isEnabled = (verticalOffset == 0)
+        binding.refreshLayout.isEnabled = (verticalOffset == 0)
     }
 
     private fun setUpView() {
@@ -226,11 +225,11 @@ class AmityCommunityPageFragment : RxFragment(),
 
 
     private fun refreshCommunity() {
-        refreshLayout?.isRefreshing = true
+        binding.refreshLayout?.isRefreshing = true
         refreshProfile()
         refreshFeed()
         Handler(Looper.getMainLooper()).postDelayed({
-            refreshLayout?.isRefreshing = false
+            binding.refreshLayout?.isRefreshing = false
         }, 1000)
     }
 

--- a/social/src/main/java/com/amity/socialcloud/uikit/community/domain/model/AmityFileAttachment.kt
+++ b/social/src/main/java/com/amity/socialcloud/uikit/community/domain/model/AmityFileAttachment.kt
@@ -4,7 +4,7 @@ import android.net.Uri
 import android.os.Parcelable
 import com.amity.socialcloud.uikit.community.newsfeed.model.FileUploadState
 import com.google.common.base.Objects
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class AmityFileAttachment(

--- a/social/src/main/java/com/amity/socialcloud/uikit/community/edit/AmityCommunityEditorFragment.kt
+++ b/social/src/main/java/com/amity/socialcloud/uikit/community/edit/AmityCommunityEditorFragment.kt
@@ -5,7 +5,6 @@ import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.ViewModelProvider
 import com.amity.socialcloud.sdk.social.community.AmityCommunity
-import com.amity.socialcloud.uikit.community.R
 import com.amity.socialcloud.uikit.community.ui.view.AmityCommunityCreateBaseFragment
 import com.amity.socialcloud.uikit.community.ui.viewModel.AmityCreateCommunityViewModel
 import com.bumptech.glide.Glide
@@ -39,7 +38,7 @@ class AmityCommunityEditorFragment : AmityCommunityCreateBaseFragment() {
             Glide.with(requireContext())
                 .load(viewModel.avatarUrl.get())
                 .centerCrop()
-                .into(mBinding.ccAvatar)
+                .into(binding.ccAvatar)
         }
     }
 

--- a/social/src/main/java/com/amity/socialcloud/uikit/community/edit/AmityCommunityProfileActivity.kt
+++ b/social/src/main/java/com/amity/socialcloud/uikit/community/edit/AmityCommunityProfileActivity.kt
@@ -7,15 +7,16 @@ import androidx.activity.viewModels
 import androidx.appcompat.app.ActionBar
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
-import androidx.lifecycle.Observer
 import com.amity.socialcloud.uikit.common.components.AmityToolBarClickListener
 import com.amity.socialcloud.uikit.community.R
+import com.amity.socialcloud.uikit.community.databinding.AmityActivityEditCommunityBinding
 import com.amity.socialcloud.uikit.community.ui.viewModel.AmityCreateCommunityViewModel
-import kotlinx.android.synthetic.main.amity_activity_create_community.*
-import kotlinx.android.synthetic.main.amity_activity_edit_community.*
 
 class AmityCommunityProfileActivity : AppCompatActivity(), AmityToolBarClickListener {
 
+    private val binding: AmityActivityEditCommunityBinding by lazy {
+        AmityActivityEditCommunityBinding.inflate(layoutInflater)
+    }
     private lateinit var mFragment: AmityCommunityEditorFragment
     private val mViewModel: AmityCreateCommunityViewModel by viewModels()
     private var communityId = ""
@@ -31,7 +32,7 @@ class AmityCommunityProfileActivity : AppCompatActivity(), AmityToolBarClickList
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.amity_activity_edit_community)
+        setContentView(binding.root)
 
         communityId = intent?.getStringExtra(COMMUNITY_ID) ?: ""
         setUpToolbar()
@@ -42,14 +43,16 @@ class AmityCommunityProfileActivity : AppCompatActivity(), AmityToolBarClickList
     }
 
     private fun setUpToolbar() {
-        editCommunityToolbar.setLeftDrawable(
-            ContextCompat.getDrawable(this, R.drawable.amity_ic_arrow_back)
-        )
-        editCommunityToolbar.setLeftString(getString(R.string.amity_edit_profile))
+        binding.editCommunityToolbar.apply {
+            setLeftDrawable(
+                    ContextCompat.getDrawable(this@AmityCommunityProfileActivity, R.drawable.amity_ic_arrow_back)
+            )
+            setLeftString(getString(R.string.amity_edit_profile))
 
-        editCommunityToolbar.setClickListener(this)
-        supportActionBar?.displayOptions = ActionBar.DISPLAY_SHOW_CUSTOM
-        setSupportActionBar(communityToolbar)
+            setClickListener(this@AmityCommunityProfileActivity)
+            supportActionBar?.displayOptions = ActionBar.DISPLAY_SHOW_CUSTOM
+            setSupportActionBar(this)
+        }
     }
 
     private fun loadFragment() {

--- a/social/src/main/java/com/amity/socialcloud/uikit/community/explore/fragments/AmityBaseCategoryListFragment.kt
+++ b/social/src/main/java/com/amity/socialcloud/uikit/community/explore/fragments/AmityBaseCategoryListFragment.kt
@@ -12,17 +12,20 @@ import com.amity.socialcloud.uikit.common.base.AmityBaseFragment
 import com.amity.socialcloud.uikit.common.common.showSnackBar
 import com.amity.socialcloud.uikit.common.utils.AmityRecyclerViewItemDecoration
 import com.amity.socialcloud.uikit.community.R
+import com.amity.socialcloud.uikit.community.databinding.AmityFragmentCategoryListBinding
 import com.amity.socialcloud.uikit.community.explore.adapter.AmityCategoryListAdapter
 import com.amity.socialcloud.uikit.community.explore.listener.AmityCategoryItemClickListener
 import com.amity.socialcloud.uikit.community.explore.viewmodel.AmityCategoryListViewModel
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.schedulers.Schedulers
-import kotlinx.android.synthetic.main.amity_fragment_category_list.*
 
 const val ARG_DEFAULT_SELECTION = "default_selection"
 
 abstract class AmityBaseCategoryListFragment internal constructor() : AmityBaseFragment(),
     AmityCategoryItemClickListener {
+
+    private var _binding: AmityFragmentCategoryListBinding? = null
+    private val binding get() = _binding!!
 
     internal lateinit var viewModel: AmityCategoryListViewModel
 
@@ -40,7 +43,8 @@ abstract class AmityBaseCategoryListFragment internal constructor() : AmityBaseF
         savedInstanceState: Bundle?
     ): View? {
         viewModel = ViewModelProvider(requireActivity()).get(AmityCategoryListViewModel::class.java)
-        return inflater.inflate(R.layout.amity_fragment_category_list, container, false)
+        _binding = AmityFragmentCategoryListBinding.inflate(inflater, container, false)
+        return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -54,9 +58,9 @@ abstract class AmityBaseCategoryListFragment internal constructor() : AmityBaseF
     private fun initView() {
         val itemDecorSpace =
             AmityRecyclerViewItemDecoration(resources.getDimensionPixelSize(R.dimen.amity_padding_xs))
-        rvCategory.layoutManager = LinearLayoutManager(requireContext())
-        rvCategory.adapter = adapter
-        rvCategory.addItemDecoration(itemDecorSpace)
+        binding.rvCategory.layoutManager = LinearLayoutManager(requireContext())
+        binding.rvCategory.adapter = adapter
+        binding.rvCategory.addItemDecoration(itemDecorSpace)
     }
 
     private fun getCategories() {
@@ -74,6 +78,11 @@ abstract class AmityBaseCategoryListFragment internal constructor() : AmityBaseF
                     adapter.submitList(result)
                 }
             })
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     override fun onCategorySelected(category: AmityCommunityCategory) {

--- a/social/src/main/java/com/amity/socialcloud/uikit/community/explore/fragments/AmityCategoryCommunityListFragment.kt
+++ b/social/src/main/java/com/amity/socialcloud/uikit/community/explore/fragments/AmityCategoryCommunityListFragment.kt
@@ -7,7 +7,6 @@ import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.amity.socialcloud.sdk.social.community.AmityCommunity
 import com.amity.socialcloud.sdk.social.community.AmityCommunityCategory
@@ -22,7 +21,6 @@ import com.amity.socialcloud.uikit.community.explore.listener.AmityCommunityItem
 import com.amity.socialcloud.uikit.community.explore.viewmodel.AmityCategoryCommunityListViewModel
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.schedulers.Schedulers
-import kotlinx.android.synthetic.main.amity_fragment_category_community_list.*
 
 const val ARG_CATEGORY_ID = "Category_id"
 const val ARG_CATEGORY_NAME = "Category_name"
@@ -33,7 +31,7 @@ class AmityCategoryCommunityListFragment : AmityBaseFragment(),
     private lateinit var adapter: AmityCategoryCommunityListAdapter
     private var categoryId: String? = null
     private var categoryName: String? = null
-    lateinit var mBinding: AmityFragmentCategoryCommunityListBinding
+    lateinit var binding: AmityFragmentCategoryCommunityListBinding
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -44,14 +42,14 @@ class AmityCategoryCommunityListFragment : AmityBaseFragment(),
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
-        mBinding = DataBindingUtil.inflate(
+    ): View {
+        binding = DataBindingUtil.inflate(
             inflater,
             R.layout.amity_fragment_category_community_list,
             container,
             false
         )
-        return mBinding.root
+        return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -74,9 +72,9 @@ class AmityCategoryCommunityListFragment : AmityBaseFragment(),
     private fun initView() {
         val itemDecorSpace =
             AmityRecyclerViewItemDecoration(resources.getDimensionPixelSize(R.dimen.amity_padding_xs))
-        rvCommunity.layoutManager = LinearLayoutManager(requireContext())
-        rvCommunity.adapter = adapter
-        rvCommunity.addItemDecoration(itemDecorSpace)
+        binding.rvCommunity.layoutManager = LinearLayoutManager(requireContext())
+        binding.rvCommunity.adapter = adapter
+        binding.rvCommunity.addItemDecoration(itemDecorSpace)
     }
 
     private fun getCategories() {
@@ -98,8 +96,8 @@ class AmityCategoryCommunityListFragment : AmityBaseFragment(),
     }
 
     private fun handleListVisibility() {
-        rvCommunity.visibility = if (adapter.itemCount > 0) View.VISIBLE else View.GONE
-        emptyView.visibility = if (adapter.itemCount > 0) View.GONE else View.VISIBLE
+        binding.rvCommunity.visibility = if (adapter.itemCount > 0) View.VISIBLE else View.GONE
+        binding.emptyView.visibility = if (adapter.itemCount > 0) View.GONE else View.VISIBLE
     }
 
 

--- a/social/src/main/java/com/amity/socialcloud/uikit/community/followers/AmityUserFollowerFragment.kt
+++ b/social/src/main/java/com/amity/socialcloud/uikit/community/followers/AmityUserFollowerFragment.kt
@@ -1,24 +1,28 @@
 package com.amity.socialcloud.uikit.community.followers
 
 import android.os.Bundle
+import android.view.LayoutInflater
 import android.view.View
+import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.widget.doAfterTextChanged
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.amity.socialcloud.sdk.core.user.AmityUser
 import com.amity.socialcloud.uikit.community.R
+import com.amity.socialcloud.uikit.community.databinding.AmityUserFollowerFragmentBinding
 import com.amity.socialcloud.uikit.community.newsfeed.listener.AmityUserClickListener
 import com.amity.socialcloud.uikit.social.AmitySocialUISettings
 import com.ekoapp.rxlifecycle.extension.untilLifecycleEnd
 import com.trello.rxlifecycle3.components.support.RxFragment
 import io.reactivex.disposables.Disposable
 import io.reactivex.subjects.PublishSubject
-import kotlinx.android.synthetic.main.amity_user_follower_fragment.*
 import java.util.concurrent.TimeUnit
 
-class AmityUserFollowerFragment :
-    RxFragment(R.layout.amity_user_follower_fragment) {
+class AmityUserFollowerFragment : RxFragment() {
+    private var _binding: AmityUserFollowerFragmentBinding? = null
+    private val binding get() = _binding!!
+
     lateinit var viewModel: AmityUserFollowerViewModel
     private var textChangeDisposable: Disposable? = null
     private val textChangeSubject: PublishSubject<String> by lazy {
@@ -26,13 +30,18 @@ class AmityUserFollowerFragment :
     }
     private lateinit var followerAdapter: AmityFollowerAdapter
 
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        _binding = AmityUserFollowerFragmentBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         viewModel = ViewModelProvider(requireActivity()).get(AmityUserFollowerViewModel::class.java)
         setupRecyclerView()
         subscribeSearchStringChange()
-        refreshLayout.setColorSchemeResources(R.color.amityColorPrimary)
-        refreshLayout.setOnRefreshListener {
+        binding.refreshLayout.setColorSchemeResources(R.color.amityColorPrimary)
+        binding.refreshLayout.setOnRefreshListener {
             refresh()
         }
     }
@@ -47,7 +56,7 @@ class AmityUserFollowerFragment :
         followerAdapter = AmityFollowerAdapter(requireContext(),
             userClickListener,
             viewModel.isSelf())
-        rvUserFollowers.apply {
+        binding.rvUserFollowers.apply {
             adapter = followerAdapter
             layoutManager = LinearLayoutManager(requireContext())
             setHasFixedSize(true)
@@ -57,14 +66,14 @@ class AmityUserFollowerFragment :
 
     private fun getFollowers() {
         viewModel.getFollowersList {
-            refreshLayout.isRefreshing = false
+            binding.refreshLayout.isRefreshing = false
             followerAdapter.submitList(it)
         }.untilLifecycleEnd(this)
             .subscribe()
     }
 
     private fun subscribeSearchStringChange() {
-        etSearch.doAfterTextChanged {
+        binding.etSearch.doAfterTextChanged {
             if (it != null) {
                 textChangeSubject.onNext(it.toString())
             }
@@ -85,7 +94,7 @@ class AmityUserFollowerFragment :
     }
 
     private fun refresh() {
-        refreshLayout.isRefreshing = true
+        binding.refreshLayout.isRefreshing = true
         getFollowers()
     }
 
@@ -94,6 +103,7 @@ class AmityUserFollowerFragment :
             textChangeDisposable?.dispose()
         }
         super.onDestroyView()
+        _binding = null
     }
 
     class Builder internal constructor() {

--- a/social/src/main/java/com/amity/socialcloud/uikit/community/followers/AmityUserFollowerHomeFragment.kt
+++ b/social/src/main/java/com/amity/socialcloud/uikit/community/followers/AmityUserFollowerHomeFragment.kt
@@ -1,16 +1,25 @@
 package com.amity.socialcloud.uikit.community.followers
 
 import android.os.Bundle
+import android.view.LayoutInflater
 import android.view.View
+import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
 import com.amity.socialcloud.uikit.common.base.AmityFragmentStateAdapter
 import com.amity.socialcloud.uikit.community.R
+import com.amity.socialcloud.uikit.community.databinding.AmityUserFollowerHomeFragmentBinding
 import com.amity.socialcloud.uikit.community.following.AmityUserFollowingFragment
 import com.trello.rxlifecycle3.components.support.RxFragment
-import kotlinx.android.synthetic.main.amity_user_follower_home_fragment.*
 
-class AmityUserFollowerHomeFragment :
-    RxFragment(R.layout.amity_user_follower_home_fragment) {
+class AmityUserFollowerHomeFragment : RxFragment() {
+
+    private var _binding: AmityUserFollowerHomeFragmentBinding? = null
+    private val binding get() = _binding!!
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        _binding = AmityUserFollowerHomeFragmentBinding.inflate(inflater, container, false)
+        return binding.root
+    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -34,8 +43,13 @@ class AmityUserFollowerHomeFragment :
                     )
                 )
             )
-            followersTabLayout.setAdapter(fragmentStateAdapter)
+            binding.followersTabLayout.setAdapter(fragmentStateAdapter)
         }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     class Builder internal constructor() {

--- a/social/src/main/java/com/amity/socialcloud/uikit/community/following/AmityUserFollowingFragment.kt
+++ b/social/src/main/java/com/amity/socialcloud/uikit/community/following/AmityUserFollowingFragment.kt
@@ -1,24 +1,29 @@
 package com.amity.socialcloud.uikit.community.following
 
 import android.os.Bundle
+import android.view.LayoutInflater
 import android.view.View
+import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.widget.doAfterTextChanged
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.amity.socialcloud.sdk.core.user.AmityUser
 import com.amity.socialcloud.uikit.community.R
+import com.amity.socialcloud.uikit.community.databinding.AmityUserFollowerHomeFragmentBinding
+import com.amity.socialcloud.uikit.community.databinding.AmityUserFollowingFragmentBinding
 import com.amity.socialcloud.uikit.community.newsfeed.listener.AmityUserClickListener
 import com.amity.socialcloud.uikit.social.AmitySocialUISettings
 import com.ekoapp.rxlifecycle.extension.untilLifecycleEnd
 import com.trello.rxlifecycle3.components.support.RxFragment
 import io.reactivex.disposables.Disposable
 import io.reactivex.subjects.PublishSubject
-import kotlinx.android.synthetic.main.amity_user_following_fragment.*
 import java.util.concurrent.TimeUnit
 
-class AmityUserFollowingFragment :
-    RxFragment(R.layout.amity_user_following_fragment) {
+class AmityUserFollowingFragment : RxFragment() {
+
+    private var _binding: AmityUserFollowingFragmentBinding? = null
+    private val binding get() = _binding!!
 
     lateinit var viewModel: AmityUserFollowingViewModel
     private var textChangeDisposable: Disposable? = null
@@ -27,13 +32,18 @@ class AmityUserFollowingFragment :
     }
     private lateinit var followingAdapter: AmityFollowingAdapter
 
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        _binding = AmityUserFollowingFragmentBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         viewModel = ViewModelProvider(requireActivity()).get(AmityUserFollowingViewModel::class.java)
         setUpRecyclerView()
         subscribeSearchStringChange()
-        refreshLayout.setColorSchemeResources(R.color.amityColorPrimary)
-        refreshLayout.setOnRefreshListener {
+        binding.refreshLayout.setColorSchemeResources(R.color.amityColorPrimary)
+        binding.refreshLayout.setOnRefreshListener {
             refresh()
         }
     }
@@ -45,7 +55,7 @@ class AmityUserFollowingFragment :
             }
         }
         followingAdapter = AmityFollowingAdapter(requireContext(), userClickListener)
-        rvUserFollowing.apply {
+        binding.rvUserFollowing.apply {
             adapter = followingAdapter
             layoutManager = LinearLayoutManager(requireContext())
             setHasFixedSize(true)
@@ -55,19 +65,19 @@ class AmityUserFollowingFragment :
 
     private fun getFollowing() {
         viewModel.getFollowingList {
-            refreshLayout.isRefreshing = false
+            binding.refreshLayout.isRefreshing = false
             followingAdapter.submitList(it)
         }.untilLifecycleEnd(this)
             .subscribe()
     }
 
     private fun refresh() {
-        refreshLayout.isRefreshing = true
+        binding.refreshLayout.isRefreshing = true
         getFollowing()
     }
 
     private fun subscribeSearchStringChange() {
-        etSearch.doAfterTextChanged {
+        binding.etSearch.doAfterTextChanged {
             if (it != null) {
                 textChangeSubject.onNext(it.toString())
             }
@@ -92,6 +102,11 @@ class AmityUserFollowingFragment :
             textChangeDisposable?.dispose()
         }
         super.onDestroy()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     class Builder internal constructor() {

--- a/social/src/main/java/com/amity/socialcloud/uikit/community/followrequest/AmityFollowRequestsFragment.kt
+++ b/social/src/main/java/com/amity/socialcloud/uikit/community/followrequest/AmityFollowRequestsFragment.kt
@@ -1,32 +1,43 @@
 package com.amity.socialcloud.uikit.community.followrequest
 
 import android.os.Bundle
+import android.view.LayoutInflater
 import android.view.View
+import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.amity.socialcloud.uikit.community.R
+import com.amity.socialcloud.uikit.community.databinding.FragmentAmityFollowRequestsBinding
 import com.ekoapp.rxlifecycle.extension.untilLifecycleEnd
 import com.trello.rxlifecycle3.components.support.RxFragment
-import kotlinx.android.synthetic.main.fragment_amity_follow_requests.*
 
-class AmityFollowRequestsFragment : RxFragment(R.layout.fragment_amity_follow_requests) {
+class AmityFollowRequestsFragment : RxFragment() {
+
+    private var _binding: FragmentAmityFollowRequestsBinding? = null
+    private val binding get() = _binding!!
+
     lateinit var viewModel: AmityFollowRequestsViewModel
     lateinit var followRequestsAdapter: AmityFollowRequestsAdapter
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        _binding = FragmentAmityFollowRequestsBinding.inflate(inflater, container, false)
+        return binding.root
+    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         viewModel = ViewModelProvider(requireActivity()).get(AmityFollowRequestsViewModel::class.java)
         setUpRecyclerView()
-        refreshLayout.setColorSchemeResources(R.color.amityColorPrimary)
-        refreshLayout.setOnRefreshListener {
+        binding.refreshLayout.setColorSchemeResources(R.color.amityColorPrimary)
+        binding.refreshLayout.setOnRefreshListener {
             refresh()
         }
     }
 
     private fun setUpRecyclerView() {
         followRequestsAdapter = AmityFollowRequestsAdapter(requireContext())
-        rvFollowRequests.apply {
+        binding.rvFollowRequests.apply {
             adapter = followRequestsAdapter
             layoutManager = LinearLayoutManager(requireContext())
         }
@@ -36,20 +47,25 @@ class AmityFollowRequestsFragment : RxFragment(R.layout.fragment_amity_follow_re
     private fun getPendingRequests() {
         viewModel.getFollowRequests(
             onSuccess = {
-                refreshLayout.isRefreshing = false
-                errorLayout.visibility = View.GONE
+                binding.refreshLayout.isRefreshing = false
+                binding.errorLayout.root.visibility = View.GONE
                 followRequestsAdapter.submitList(it)
             },
             onError = {
-                errorLayout.visibility = View.VISIBLE
+                binding.errorLayout.root.visibility = View.VISIBLE
             }
         ).untilLifecycleEnd(this)
             .subscribe()
     }
 
     private fun refresh() {
-        refreshLayout.isRefreshing = true
+        binding.refreshLayout.isRefreshing = true
         getPendingRequests()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     class Builder internal constructor() {

--- a/social/src/main/java/com/amity/socialcloud/uikit/community/home/activity/AmityCommunityHomePageActivity.kt
+++ b/social/src/main/java/com/amity/socialcloud/uikit/community/home/activity/AmityCommunityHomePageActivity.kt
@@ -4,22 +4,26 @@ import android.os.Bundle
 import androidx.appcompat.app.ActionBar
 import androidx.appcompat.app.AppCompatActivity
 import com.amity.socialcloud.uikit.community.R
+import com.amity.socialcloud.uikit.community.databinding.AmityActivityCommunityHomeBinding
 import com.amity.socialcloud.uikit.community.home.fragments.AmityCommunityHomePageFragment
-import kotlinx.android.synthetic.main.amity_activity_community_home.*
 
 class AmityCommunityHomePageActivity : AppCompatActivity() {
 
+    private val binding : AmityActivityCommunityHomeBinding by lazy {
+        AmityActivityCommunityHomeBinding.inflate(layoutInflater)
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.amity_activity_community_home)
+        setContentView(binding.root)
         initToolbar()
         loadFragment()
     }
 
     private fun initToolbar() {
         supportActionBar?.displayOptions = ActionBar.DISPLAY_SHOW_CUSTOM
-        setSupportActionBar(communityHomeToolbar)
-        communityHomeToolbar.setLeftString(getString(R.string.amity_community))
+        setSupportActionBar(binding.communityHomeToolbar)
+        binding.communityHomeToolbar.setLeftString(getString(R.string.amity_community))
     }
 
     private fun loadFragment() {

--- a/social/src/main/java/com/amity/socialcloud/uikit/community/home/fragments/AmityCommunityHomePageFragment.kt
+++ b/social/src/main/java/com/amity/socialcloud/uikit/community/home/fragments/AmityCommunityHomePageFragment.kt
@@ -27,7 +27,6 @@ import com.amity.socialcloud.uikit.community.search.AmityUserSearchFragment
 import com.amity.socialcloud.uikit.community.setting.AmityCommunitySearchFragment
 import io.reactivex.disposables.Disposable
 import io.reactivex.subjects.PublishSubject
-import kotlinx.android.synthetic.main.amity_fragment_community_home_page.*
 import java.util.concurrent.TimeUnit
 
 
@@ -96,7 +95,7 @@ class AmityCommunityHomePageFragment : Fragment() {
                 )
             )
         )
-        tabLayout.setAdapter(fragmentStateAdapter)
+        binding.tabLayout.setAdapter(fragmentStateAdapter)
     }
 
     private fun getExploreFragment(): Fragment {
@@ -112,7 +111,7 @@ class AmityCommunityHomePageFragment : Fragment() {
             when (event.type) {
                 AmityEventIdentifier.EXPLORE_COMMUNITY -> {
                     //searchMenuItem.expandActionView()
-                    tabLayout.switchTab(1)
+                    binding.tabLayout.switchTab(1)
                 }
                 else -> {
 

--- a/social/src/main/java/com/amity/socialcloud/uikit/community/mycommunity/fragment/AmityMyCommunityFragment.kt
+++ b/social/src/main/java/com/amity/socialcloud/uikit/community/mycommunity/fragment/AmityMyCommunityFragment.kt
@@ -27,7 +27,6 @@ import com.amity.socialcloud.uikit.community.mycommunity.viewmodel.AmityMyCommun
 import com.amity.socialcloud.uikit.community.ui.view.AmityCommunityCreatorActivity
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.schedulers.Schedulers
-import kotlinx.android.synthetic.main.amity_fragment_my_community.*
 
 private const val ARG_SHOW_SEARCH = "ARG_SHOW_SEARCH"
 private const val ARG_SHOW_OPTIONS_MENU = "ARG_SHOW_OPTIONS_MENU"
@@ -69,21 +68,21 @@ class AmityMyCommunityFragment : AmityBaseFragment(),
         initRecyclerView()
         handleEditTextInput()
         if (arguments?.getBoolean(ARG_SHOW_SEARCH) != false) {
-            etSearch.visibility = View.VISIBLE
+            binding.etSearch.visibility = View.VISIBLE
         } else {
-            etSearch.visibility = View.GONE
+            binding.etSearch.visibility = View.GONE
         }
     }
 
     private fun handleEditTextInput() {
-        etSearch.setShape(
+        binding.etSearch.setShape(
             null, null, null, null,
             R.color.amityColorBase, null, AmityColorShade.SHADE4
         )
-        etSearch.setOnEditorActionListener(object : TextView.OnEditorActionListener {
+        binding.etSearch.setOnEditorActionListener(object : TextView.OnEditorActionListener {
             override fun onEditorAction(v: TextView?, actionId: Int, event: KeyEvent?): Boolean {
                 if (actionId == EditorInfo.IME_ACTION_NEXT) {
-                    AmityAndroidUtil.hideKeyboard(etSearch)
+                    AmityAndroidUtil.hideKeyboard(binding.etSearch)
                     return true
                 }
                 return false
@@ -122,15 +121,17 @@ class AmityMyCommunityFragment : AmityBaseFragment(),
 
     private fun initRecyclerView() {
         mAdapter = AmityMyCommunityListAdapter(this, false)
-        rvMyCommunities.layoutManager = LinearLayoutManager(requireContext())
-        rvMyCommunities.adapter = mAdapter
-        rvMyCommunities.addItemDecoration(
-            AmityRecyclerViewItemDecoration(
-                resources.getDimensionPixelSize(R.dimen.amity_padding_xs),
-                0, resources.getDimensionPixelSize(R.dimen.amity_padding_xs), 0
+        binding.rvMyCommunities.apply {
+            layoutManager = LinearLayoutManager(requireContext())
+            this.adapter = mAdapter
+            addItemDecoration(
+                    AmityRecyclerViewItemDecoration(
+                            resources.getDimensionPixelSize(R.dimen.amity_padding_xs),
+                            0, resources.getDimensionPixelSize(R.dimen.amity_padding_xs), 0
+                    )
             )
-        )
-        rvMyCommunities.setHasFixedSize(true)
+            setHasFixedSize(true)
+        }
 
         disposable.add(viewModel.getCommunityList().subscribeOn(Schedulers.io())
             .observeOn(AndroidSchedulers.mainThread())

--- a/social/src/main/java/com/amity/socialcloud/uikit/community/newsfeed/activity/AmityVideoPostPlayerActivity.kt
+++ b/social/src/main/java/com/amity/socialcloud/uikit/community/newsfeed/activity/AmityVideoPostPlayerActivity.kt
@@ -8,13 +8,17 @@ import androidx.core.content.ContextCompat
 import androidx.lifecycle.ViewModelProvider
 import androidx.viewpager.widget.ViewPager
 import com.amity.socialcloud.uikit.community.R
+import com.amity.socialcloud.uikit.community.databinding.AmityActivityVideoPreviewBinding
 import com.amity.socialcloud.uikit.community.newsfeed.adapter.AmityVideoPostPlayerFragmentAdapter
 import com.amity.socialcloud.uikit.community.newsfeed.viewmodel.AmityVideoPostPlayerViewModel
 import com.ekoapp.rxlifecycle.extension.untilLifecycleEnd
 import com.trello.rxlifecycle3.components.support.RxAppCompatActivity
-import kotlinx.android.synthetic.main.amity_activity_video_preview.*
 
 class AmityVideoPostPlayerActivity : RxAppCompatActivity() {
+
+    private val binding by lazy {
+        AmityActivityVideoPreviewBinding.inflate(layoutInflater)
+    }
 
     private lateinit var viewModel: AmityVideoPostPlayerViewModel
     private lateinit var videoFragmentAdapter: AmityVideoPostPlayerFragmentAdapter
@@ -64,13 +68,13 @@ class AmityVideoPostPlayerActivity : RxAppCompatActivity() {
             override fun onPageScrollStateChanged(state: Int) {
             }
         }
-        videoViewPages.adapter = videoFragmentAdapter
+        binding.videoViewPages.adapter = videoFragmentAdapter
     }
 
     private fun getVideoData() {
         viewModel.getVideoData { videoDataList ->
             videoFragmentAdapter.setItems(videoDataList)
-            videoViewPages.setCurrentItem(viewModel.videoPos, false)
+            binding.videoViewPages.setCurrentItem(viewModel.videoPos, false)
             setToolbarTitle(viewModel.videoPos)
         }
             .untilLifecycleEnd(this)
@@ -79,16 +83,16 @@ class AmityVideoPostPlayerActivity : RxAppCompatActivity() {
 
     override fun onResume() {
         super.onResume()
-        videoViewPages.addOnPageChangeListener(pageChangeCallback)
+        binding.videoViewPages.addOnPageChangeListener(pageChangeCallback)
     }
 
     override fun onPause() {
         super.onPause()
-        videoViewPages.removeOnPageChangeListener(pageChangeCallback)
+        binding.videoViewPages.removeOnPageChangeListener(pageChangeCallback)
     }
 
     private fun initToolbar() {
-        setSupportActionBar(toolbar)
+        setSupportActionBar(binding.toolbar)
         supportActionBar?.setHomeAsUpIndicator(R.drawable.amity_ic_close)
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
         supportActionBar?.setDisplayHomeAsUpEnabled(true)

--- a/social/src/main/java/com/amity/socialcloud/uikit/community/newsfeed/activity/AmityVideoPostPlayerActivity.kt
+++ b/social/src/main/java/com/amity/socialcloud/uikit/community/newsfeed/activity/AmityVideoPostPlayerActivity.kt
@@ -44,7 +44,7 @@ class AmityVideoPostPlayerActivity : RxAppCompatActivity() {
         intent.getStringExtra(EXTRA_PARENT_POST_ID)?.let { viewModel.postId = it }
         viewModel.videoPos = intent.getIntExtra(EXTRA_VIDEO_POSITION, 0)
         window.statusBarColor = ContextCompat.getColor(this, R.color.amityColorSecondary)
-        setContentView(R.layout.amity_activity_video_preview)
+        setContentView(binding.root)
         initToolbar()
         initViewPager()
         getVideoData()

--- a/social/src/main/java/com/amity/socialcloud/uikit/community/newsfeed/fragment/AmityPostTargetPickerFragment.kt
+++ b/social/src/main/java/com/amity/socialcloud/uikit/community/newsfeed/fragment/AmityPostTargetPickerFragment.kt
@@ -22,7 +22,6 @@ import com.amity.socialcloud.uikit.community.utils.EXTRA_PARAM_POST_CREATION_TYP
 import com.bumptech.glide.Glide
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.schedulers.Schedulers
-import kotlinx.android.synthetic.main.amity_fragment_post_target_selection.*
 
 class AmityPostTargetPickerFragment : AmityBaseFragment(),
     AmityCreatePostCommunitySelectionListener {
@@ -85,7 +84,7 @@ class AmityPostTargetPickerFragment : AmityBaseFragment(),
             arguments?.getString(EXTRA_PARAM_POST_CREATION_TYPE) ?: POST_CREATION_TYPE_GENERIC
         initRecyclerView()
         initProfileImage()
-        clMyTimeline.setOnClickListener { launchPostCreator() }
+        binding.clMyTimeline.setOnClickListener { launchPostCreator() }
     }
 
     private fun launchPostCreator() {
@@ -109,20 +108,22 @@ class AmityPostTargetPickerFragment : AmityBaseFragment(),
             .load(imageURL)
             .placeholder(R.drawable.amity_ic_default_profile_large)
             .centerCrop()
-            .into(avProfile)
+            .into(binding.avProfile)
     }
 
     private fun initRecyclerView() {
         adapter = AmityCreatePostCommunitySelectionAdapter(this)
-        rvCommunity.layoutManager = LinearLayoutManager(requireContext())
-        rvCommunity.adapter = adapter
-        rvCommunity.addItemDecoration(
-            AmityRecyclerViewItemDecoration(
-                resources.getDimensionPixelSize(R.dimen.amity_padding_xs),
-                0, resources.getDimensionPixelSize(R.dimen.amity_padding_xs)
+        binding.rvCommunity.apply {
+            layoutManager = LinearLayoutManager(requireContext())
+            this.adapter = adapter
+            addItemDecoration(
+                    AmityRecyclerViewItemDecoration(
+                            resources.getDimensionPixelSize(R.dimen.amity_padding_xs),
+                            0, resources.getDimensionPixelSize(R.dimen.amity_padding_xs)
+                    )
             )
-        )
-        rvCommunity.hasFixedSize()
+            hasFixedSize()
+        }
         getCommunity()
     }
 

--- a/social/src/main/java/com/amity/socialcloud/uikit/community/newsfeed/fragment/AmityVideoPostPlayerFragment.kt
+++ b/social/src/main/java/com/amity/socialcloud/uikit/community/newsfeed/fragment/AmityVideoPostPlayerFragment.kt
@@ -11,6 +11,7 @@ import com.amity.socialcloud.sdk.social.feed.AmityPost
 import com.amity.socialcloud.uikit.common.base.AmityBaseFragment
 import com.amity.socialcloud.uikit.common.utils.safeLet
 import com.amity.socialcloud.uikit.community.R
+import com.amity.socialcloud.uikit.community.databinding.AmityFragmentSocialVideoPlayerBinding
 import com.google.android.exoplayer2.MediaItem
 import com.google.android.exoplayer2.SimpleExoPlayer
 import com.google.android.exoplayer2.extractor.DefaultExtractorsFactory
@@ -21,18 +22,20 @@ import com.google.android.exoplayer2.upstream.DefaultDataSourceFactory
 import com.google.android.exoplayer2.util.Util
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.schedulers.Schedulers
-import kotlinx.android.synthetic.main.amity_fragment_social_video_player.*
 
 internal class AmityVideoPostPlayerFragment : AmityBaseFragment() {
 
+    private var _binding: AmityFragmentSocialVideoPlayerBinding? = null
+    private val binding get() = _binding!!
     private var exoplayer: SimpleExoPlayer? = null
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
-        return inflater.inflate(R.layout.amity_fragment_social_video_player, container, false)
+    ): View {
+        _binding = AmityFragmentSocialVideoPlayerBinding.inflate(inflater, container, false)
+        return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -51,12 +54,12 @@ internal class AmityVideoPostPlayerFragment : AmityBaseFragment() {
     private fun setupPlayer(context: Context) {
         exoplayer = SimpleExoPlayer.Builder(context).build()
         exoplayer?.playWhenReady = false
-        video_viewer?.player = exoplayer
+        binding.videoViewer.player = exoplayer
     }
 
     private fun prepareVideo(url: String?) {
         safeLet(url, context) { nonNullUrl, nonNullContext ->
-            video_viewer?.requestFocus()
+            binding.videoViewer.requestFocus()
             val dataSourceFactory: DataSource.Factory = DefaultDataSourceFactory(
                 nonNullContext,
                 Util.getUserAgent(nonNullContext, resources.getString(R.string.app_name))
@@ -74,6 +77,11 @@ internal class AmityVideoPostPlayerFragment : AmityBaseFragment() {
         super.onDestroy()
         exoplayer?.stop()
         exoplayer?.release()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     internal class Builder internal constructor() {

--- a/social/src/main/java/com/amity/socialcloud/uikit/community/newsfeed/fragment/AmityVideoSimplePlayerFragment.kt
+++ b/social/src/main/java/com/amity/socialcloud/uikit/community/newsfeed/fragment/AmityVideoSimplePlayerFragment.kt
@@ -9,6 +9,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import com.amity.socialcloud.uikit.common.utils.safeLet
 import com.amity.socialcloud.uikit.community.R
+import com.amity.socialcloud.uikit.community.databinding.AmityFragmentSocialVideoPlayerBinding
 import com.google.android.exoplayer2.MediaItem
 import com.google.android.exoplayer2.SimpleExoPlayer
 import com.google.android.exoplayer2.extractor.DefaultExtractorsFactory
@@ -17,21 +18,23 @@ import com.google.android.exoplayer2.source.ProgressiveMediaSource
 import com.google.android.exoplayer2.upstream.DataSource
 import com.google.android.exoplayer2.upstream.DefaultDataSourceFactory
 import com.google.android.exoplayer2.util.Util
-import kotlinx.android.synthetic.main.amity_fragment_social_video_player.*
 
 internal class AmitySimpleVideoPlayerFragment : Fragment() {
+
+    private var _binding: AmityFragmentSocialVideoPlayerBinding? = null
+    private val binding get() = _binding!!
 
     private var exoplayer: SimpleExoPlayer? = null
     private var videoUrl: String? = null
     private var currentPosition = 0
 
-
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
-        return inflater.inflate(R.layout.amity_fragment_social_video_player, container, false)
+    ): View {
+        _binding = AmityFragmentSocialVideoPlayerBinding.inflate(inflater, container, false)
+        return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -39,7 +42,7 @@ internal class AmitySimpleVideoPlayerFragment : Fragment() {
         context?.let { nonNullContext ->
             exoplayer = SimpleExoPlayer.Builder(nonNullContext).build()
             exoplayer?.playWhenReady = true
-            video_viewer?.player = exoplayer
+            binding.videoViewer.player = exoplayer
             if (savedInstanceState != null) {
                 val videoUrl = savedInstanceState.getString(ARG_VIDEO_URL)
                 currentPosition = savedInstanceState.getInt(ARG_VIDEO_CURRENT_POSITION)
@@ -53,7 +56,7 @@ internal class AmitySimpleVideoPlayerFragment : Fragment() {
 
     private fun prepareVideo(url: String?) {
         safeLet(url, context) { nonNullUrl, nonNullContext ->
-            video_viewer?.requestFocus()
+            binding.videoViewer.requestFocus()
             val dataSourceFactory: DataSource.Factory = DefaultDataSourceFactory(
                 nonNullContext,
                 Util.getUserAgent(nonNullContext, resources.getString(R.string.app_name))
@@ -77,6 +80,11 @@ internal class AmitySimpleVideoPlayerFragment : Fragment() {
         super.onDestroy()
         exoplayer?.stop()
         exoplayer?.release()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     internal class Builder internal constructor() {

--- a/social/src/main/java/com/amity/socialcloud/uikit/community/newsfeed/model/AmityPostAttachmentOptionItem.kt
+++ b/social/src/main/java/com/amity/socialcloud/uikit/community/newsfeed/model/AmityPostAttachmentOptionItem.kt
@@ -2,7 +2,7 @@ package com.amity.socialcloud.uikit.community.newsfeed.model
 
 import android.os.Parcelable
 import com.amity.socialcloud.uikit.community.R
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 sealed class AmityPostAttachmentOptionItem(
     val activeIcon: Int,

--- a/social/src/main/java/com/amity/socialcloud/uikit/community/newsfeed/model/PostMedia.kt
+++ b/social/src/main/java/com/amity/socialcloud/uikit/community/newsfeed/model/PostMedia.kt
@@ -2,7 +2,7 @@ package com.amity.socialcloud.uikit.community.newsfeed.model
 
 import android.net.Uri
 import android.os.Parcelable
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class PostMedia(

--- a/social/src/main/java/com/amity/socialcloud/uikit/community/profile/fragment/AmityUserProfileEditorFragment.kt
+++ b/social/src/main/java/com/amity/socialcloud/uikit/community/profile/fragment/AmityUserProfileEditorFragment.kt
@@ -26,9 +26,7 @@ import com.bumptech.glide.Glide
 import com.google.android.material.snackbar.Snackbar
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.schedulers.Schedulers
-import kotlinx.android.synthetic.main.amity_fragment_edit_user_profile.*
 import java.io.File
-
 
 class AmityUserProfileEditorFragment : AmityPickerFragment() {
     private var menuItemSaveProfile: MenuItem? = null
@@ -70,8 +68,8 @@ class AmityUserProfileEditorFragment : AmityPickerFragment() {
 
         observeProfileUpdate()
 
-        etDisplayName.filters = arrayOf<InputFilter>(LengthFilter(viewModel.userNameMaxTextLength))
-        etAbout.filters = arrayOf<InputFilter>(LengthFilter(viewModel.aboutMaxTextLength))
+        binding.etDisplayName.filters = arrayOf<InputFilter>(LengthFilter(viewModel.userNameMaxTextLength))
+        binding.etAbout.filters = arrayOf<InputFilter>(LengthFilter(viewModel.aboutMaxTextLength))
     }
 
 

--- a/social/src/main/java/com/amity/socialcloud/uikit/community/profile/fragment/AmityUserProfilePageFragment.kt
+++ b/social/src/main/java/com/amity/socialcloud/uikit/community/profile/fragment/AmityUserProfilePageFragment.kt
@@ -41,11 +41,6 @@ import io.reactivex.BackpressureStrategy
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.schedulers.Schedulers
 import io.reactivex.subjects.PublishSubject
-import kotlinx.android.synthetic.main.amity_fragment_community_home_page.tabLayout
-import kotlinx.android.synthetic.main.amity_fragment_user_profile_page.appBar
-import kotlinx.android.synthetic.main.amity_fragment_user_profile_page.fabCreatePost
-import kotlinx.android.synthetic.main.amity_fragment_user_profile_page.refreshLayout
-import kotlinx.android.synthetic.main.amity_view_user_profile_header.*
 import timber.log.Timber
 
 const val ARG_USER_ID = "ARG_USER_ID"
@@ -116,15 +111,15 @@ class AmityUserProfilePageFragment : AmityBaseFragment(),
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         initTabLayout()
-        appBar.setExpanded(true)
+        binding.appBar.setExpanded(true)
         getUserDetails()
-        fabCreatePost.setSafeOnClickListener {
+        binding.fabCreatePost.setSafeOnClickListener {
             navigateToCreatePost()
         }
         setHeaderViewClickListeners()
 
-        refreshLayout.setColorSchemeResources(R.color.amityColorPrimary)
-        refreshLayout.setOnRefreshListener {
+        binding.refreshLayout.setColorSchemeResources(R.color.amityColorPrimary)
+        binding.refreshLayout.setOnRefreshListener {
             refreshFeed()
         }
     }
@@ -132,24 +127,24 @@ class AmityUserProfilePageFragment : AmityBaseFragment(),
     override fun onStart() {
         super.onStart()
         if (!isRefreshing) {
-            refreshLayout?.isRefreshing = true
+            binding.refreshLayout?.isRefreshing = true
             refreshFeed()
         }
         isRefreshing = true
     }
 
     override fun onOffsetChanged(appBarLayout: AppBarLayout?, verticalOffset: Int) {
-        refreshLayout.isEnabled = (verticalOffset == 0)
+        binding.refreshLayout.isEnabled = (verticalOffset == 0)
     }
 
     override fun onResume() {
         super.onResume()
-        appBar.addOnOffsetChangedListener(this)
+        binding.appBar.addOnOffsetChangedListener(this)
     }
 
     override fun onPause() {
         super.onPause()
-        appBar.removeOnOffsetChangedListener(this)
+        binding.appBar.removeOnOffsetChangedListener(this)
     }
 
     private fun navigateToCreatePost() {
@@ -197,7 +192,7 @@ class AmityUserProfilePageFragment : AmityBaseFragment(),
             }
         }
         Handler(Looper.getMainLooper()).postDelayed({
-            refreshLayout?.isRefreshing = false
+            binding.refreshLayout.isRefreshing = false
         }, 1000)
         getFollowInfo()
     }
@@ -282,7 +277,7 @@ class AmityUserProfilePageFragment : AmityBaseFragment(),
                     .subscribe({ result ->
                         binding.userProfileHeader.setUserData(result)
                         currentUser = result
-                        fabCreatePost.visibility =
+                        binding.fabCreatePost.visibility =
                             if (viewModel.isSelfUser()) View.VISIBLE else View.GONE
                     }, {
                         Timber.d(TAG, it.message)
@@ -329,7 +324,7 @@ class AmityUserProfilePageFragment : AmityBaseFragment(),
                 )
             )
         )
-        tabLayout.setAdapter(fragmentStateAdapter)
+        binding.tabLayout.setAdapter(fragmentStateAdapter)
     }
 
     private fun getPostGalleryFragment(): Fragment {

--- a/social/src/main/java/com/amity/socialcloud/uikit/community/setting/postreview/AmityPostReviewSettingsActivity.kt
+++ b/social/src/main/java/com/amity/socialcloud/uikit/community/setting/postreview/AmityPostReviewSettingsActivity.kt
@@ -6,13 +6,11 @@ import android.os.Bundle
 import androidx.appcompat.app.ActionBar
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.ViewModelProvider
-import com.amity.socialcloud.sdk.social.community.AmityCommunity
 import com.amity.socialcloud.uikit.common.base.AmityBaseActivity
 import com.amity.socialcloud.uikit.common.components.AmityToolBarClickListener
 import com.amity.socialcloud.uikit.community.BR
 import com.amity.socialcloud.uikit.community.R
 import com.amity.socialcloud.uikit.community.databinding.AmityActivityPostReviewSettingsBinding
-import kotlinx.android.synthetic.main.amity_activity_post_review_settings.*
 
 class AmityPostReviewSettingsActivity :
     AmityBaseActivity<AmityActivityPostReviewSettingsBinding, AmityPostReviewSettingsViewModel>(),
@@ -28,6 +26,10 @@ class AmityPostReviewSettingsActivity :
 
     }
 
+    private val binding : AmityActivityPostReviewSettingsBinding by lazy {
+        AmityActivityPostReviewSettingsBinding.inflate(layoutInflater)
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -36,19 +38,19 @@ class AmityPostReviewSettingsActivity :
     }
 
     private fun setUpToolbar() {
-        postReviewToolbar.setLeftDrawable(
+        binding.postReviewToolbar.setLeftDrawable(
             ContextCompat.getDrawable(
                 this,
                 R.drawable.amity_ic_arrow_back
             )
         )
-        postReviewToolbar.setClickListener(this)
+        binding.postReviewToolbar.setClickListener(this)
 
         val titleToolbar = getString(R.string.amity_post_review)
-        postReviewToolbar.setLeftString(titleToolbar)
+        binding.postReviewToolbar.setLeftString(titleToolbar)
 
         supportActionBar?.displayOptions = ActionBar.DISPLAY_SHOW_CUSTOM
-        setSupportActionBar(postReviewToolbar)
+        setSupportActionBar(binding.postReviewToolbar)
     }
 
     private fun loadFragment() {

--- a/social/src/main/java/com/amity/socialcloud/uikit/community/setting/postreview/AmityPostReviewSettingsFragment.kt
+++ b/social/src/main/java/com/amity/socialcloud/uikit/community/setting/postreview/AmityPostReviewSettingsFragment.kt
@@ -8,14 +8,16 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import com.amity.socialcloud.sdk.social.community.AmityCommunity
 import com.amity.socialcloud.uikit.common.utils.AmityAlertDialogUtil
 import com.amity.socialcloud.uikit.community.R
+import com.amity.socialcloud.uikit.community.databinding.AmityFragmentPostReviewBinding
 import com.amity.socialcloud.uikit.community.setting.AmitySettingsItem
 import com.amity.socialcloud.uikit.community.setting.AmitySettingsItemAdapter
 import com.ekoapp.rxlifecycle.extension.untilLifecycleEnd
 import com.trello.rxlifecycle3.components.support.RxFragment
-import kotlinx.android.synthetic.main.amity_fragment_post_review.*
 
-class AmityPostReviewSettingsFragment :
-    RxFragment(R.layout.amity_fragment_post_review) {
+class AmityPostReviewSettingsFragment : RxFragment() {
+
+    private var _binding: AmityFragmentPostReviewBinding? = null
+    private val binding get() = _binding!!
 
     private val settingsListAdapter = AmitySettingsItemAdapter()
     private lateinit var viewModel: AmityPostReviewSettingsViewModel
@@ -69,8 +71,8 @@ class AmityPostReviewSettingsFragment :
     }
 
     private fun setupPostReviewListRecyclerView() {
-        rvPostReview.layoutManager = LinearLayoutManager(context)
-        rvPostReview.adapter = settingsListAdapter
+        binding.rvPostReview.layoutManager = LinearLayoutManager(context)
+        binding.rvPostReview.adapter = settingsListAdapter
         getPostReviewItems()
     }
 
@@ -98,6 +100,11 @@ class AmityPostReviewSettingsFragment :
                 isPositive = which, confirmed = dialog::cancel
             )
         }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     class Builder internal constructor() {

--- a/social/src/main/java/com/amity/socialcloud/uikit/community/setting/user/AmityUserSettingsFragment.kt
+++ b/social/src/main/java/com/amity/socialcloud/uikit/community/setting/user/AmityUserSettingsFragment.kt
@@ -2,7 +2,9 @@ package com.amity.socialcloud.uikit.community.setting.user
 
 import android.content.DialogInterface
 import android.os.Bundle
+import android.view.LayoutInflater
 import android.view.View
+import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -10,18 +12,25 @@ import com.amity.socialcloud.sdk.core.user.AmityUser
 import com.amity.socialcloud.uikit.common.common.showSnackBar
 import com.amity.socialcloud.uikit.common.utils.AmityAlertDialogUtil
 import com.amity.socialcloud.uikit.community.R
+import com.amity.socialcloud.uikit.community.databinding.AmityFragmentUserSettingsBinding
 import com.amity.socialcloud.uikit.community.profile.activity.AmityEditUserProfileActivity
 import com.amity.socialcloud.uikit.community.setting.AmitySettingsItem
 import com.amity.socialcloud.uikit.community.setting.AmitySettingsItemAdapter
 import com.ekoapp.rxlifecycle.extension.untilLifecycleEnd
 import com.trello.rxlifecycle3.components.support.RxFragment
-import kotlinx.android.synthetic.main.amity_fragment_user_settings.*
 
-class AmityUserSettingsFragment :
-    RxFragment(R.layout.amity_fragment_user_settings) {
+class AmityUserSettingsFragment : RxFragment() {
+
+    private var _binding: AmityFragmentUserSettingsBinding? = null
+    private val binding get() = _binding!!
 
     private val settingsListAdapter = AmitySettingsItemAdapter()
     lateinit var viewModel: AmityUserSettingsViewModel
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        _binding = AmityFragmentUserSettingsBinding.inflate(inflater, container, false)
+        return binding.root
+    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -30,8 +39,8 @@ class AmityUserSettingsFragment :
     }
 
     private fun setUpSettingsRecyclerView() {
-        progressbar.visibility = View.VISIBLE
-        rvUserSettings.apply {
+        binding.progressbar.visibility = View.VISIBLE
+        binding. rvUserSettings.apply {
             adapter = settingsListAdapter
             layoutManager = LinearLayoutManager(requireContext())
         }
@@ -49,13 +58,13 @@ class AmityUserSettingsFragment :
     }
 
     private fun showErrorLayout() {
-        rvUserSettings.visibility = View.GONE
-        errorLayout.visibility = View.VISIBLE
+        binding.rvUserSettings.visibility = View.GONE
+        binding.errorLayout.root.visibility = View.VISIBLE
     }
 
     private fun renderItems(items: List<AmitySettingsItem>) {
         settingsListAdapter.setItems(items)
-        progressbar.visibility = View.GONE
+        binding.progressbar.visibility = View.GONE
     }
 
     private fun unfollowUser(userId: String) {
@@ -85,13 +94,13 @@ class AmityUserSettingsFragment :
         if (user.isFlaggedByMe()) {
             viewModel.unReportUser(user)
                 .doOnComplete {
-                    rvUserSettings.showSnackBar(getString(R.string.amity_unreport_sent))
+                    binding.rvUserSettings.showSnackBar(getString(R.string.amity_unreport_sent))
                 }.untilLifecycleEnd(this)
                 .subscribe()
         } else {
             viewModel.reportUser(user)
                 .doOnComplete {
-                    rvUserSettings.showSnackBar(getString(R.string.amity_report_sent))
+                    binding.rvUserSettings.showSnackBar(getString(R.string.amity_report_sent))
                 }.untilLifecycleEnd(this)
                 .subscribe()
         }
@@ -116,6 +125,11 @@ class AmityUserSettingsFragment :
 
     internal fun shareUserProfile(userId: String) {
 
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     class Builder internal constructor() {

--- a/social/src/main/java/com/amity/socialcloud/uikit/community/ui/view/AmityCommunityCreateBaseFragment.kt
+++ b/social/src/main/java/com/amity/socialcloud/uikit/community/ui/view/AmityCommunityCreateBaseFragment.kt
@@ -33,8 +33,6 @@ import com.trello.rxlifecycle3.components.support.RxFragment
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.schedulers.Schedulers
-import kotlinx.android.synthetic.main.amity_fragment_create_community.*
-import kotlinx.android.synthetic.main.amity_item_settings_nav_content.*
 import timber.log.Timber
 
 abstract class AmityCommunityCreateBaseFragment : RxFragment() {
@@ -43,7 +41,7 @@ abstract class AmityCommunityCreateBaseFragment : RxFragment() {
     var disposable = CompositeDisposable()
     private var imageUri: Uri? = null
     lateinit var viewModel: AmityCreateCommunityViewModel
-    internal lateinit var mBinding: AmityFragmentCreateCommunityBinding
+    internal lateinit var binding: AmityFragmentCreateCommunityBinding
 
     private val pickImage = registerForActivityResult(AmityPickImageContract()) { data ->
         if(data != null) {
@@ -53,7 +51,7 @@ abstract class AmityCommunityCreateBaseFragment : RxFragment() {
                 .load(data)
                 .centerCrop()
                 .placeholder(R.drawable.amity_ic_default_community_avatar)
-                .into(ccAvatar)
+                .into(binding.ccAvatar)
         }
     }
 
@@ -62,7 +60,7 @@ abstract class AmityCommunityCreateBaseFragment : RxFragment() {
             if (it) {
                 pickImage.launch(getString(com.amity.socialcloud.uikit.common.R.string.amity_choose_image))
             } else {
-                this.rootView.showSnackBar("Permission denied", Snackbar.LENGTH_SHORT)
+                binding.root.showSnackBar("Permission denied", Snackbar.LENGTH_SHORT)
             }
         }
 
@@ -71,24 +69,24 @@ abstract class AmityCommunityCreateBaseFragment : RxFragment() {
         savedInstanceState: Bundle?
     ): View? {
         // Inflate the layout for this fragment
-        mBinding = DataBindingUtil.inflate(
+        binding = DataBindingUtil.inflate(
             inflater,
             R.layout.amity_fragment_create_community, container, false
         )
-        mBinding.setLifecycleOwner(this)
-        return mBinding.root
+        binding.setLifecycleOwner(this)
+        return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         viewModel = ViewModelProvider(requireActivity() as AppCompatActivity).get(AmityCreateCommunityViewModel::class.java)
-        mBinding.viewModel = viewModel
+        binding.viewModel = viewModel
 
-        mBinding.category.setOnClickListener {
+        binding.category.setOnClickListener {
             launchCategorySelection(viewModel.category.get()!!)
         }
 
-        mBinding.categoryArrow.setOnClickListener {
+        binding.categoryArrow.setOnClickListener {
             launchCategorySelection(viewModel.category.get()!!)
         }
         addInitialStateChangeListener()
@@ -98,11 +96,11 @@ abstract class AmityCommunityCreateBaseFragment : RxFragment() {
     }
 
     private fun uploadImageAndCreateCommunity() {
-        mBinding.btnCreateCommunity.setOnClickListener {
+        binding.btnCreateCommunity.setOnClickListener {
             viewModel.createIdList()
             uploadImage(false)
         }
-        mBinding.btnEditCommunity.setOnClickListener {
+        binding.btnEditCommunity.setOnClickListener {
             uploadImage(true)
         }
     }
@@ -111,7 +109,7 @@ abstract class AmityCommunityCreateBaseFragment : RxFragment() {
         viewModel.setPropertyChangeCallback()
     }
 
-    fun getBindingVariable(): AmityFragmentCreateCommunityBinding = mBinding
+    fun getBindingVariable(): AmityFragmentCreateCommunityBinding = binding
 
     private fun pickImage() {
         pickImagePermission.launch(Manifest.permission.WRITE_EXTERNAL_STORAGE)
@@ -125,18 +123,18 @@ abstract class AmityCommunityCreateBaseFragment : RxFragment() {
         Glide.with(requireContext())
             .load(R.drawable.amity_ic_default_community_avatar)
             .centerCrop()
-            .into(mBinding.ccAvatar)
+            .into(binding.ccAvatar)
     }
 
     private fun setAvatar() {
 
         renderAvatar()
 
-        mBinding.lAvatar.setOnClickListener {
+        binding.lAvatar.setOnClickListener {
             pickImage()
         }
 
-        ccName.setOnTouchListener(object : View.OnTouchListener {
+        (binding.ccName as View).setOnTouchListener(object : View.OnTouchListener {
             override fun onTouch(v: View?, event: MotionEvent?): Boolean {
                 val DRAWABLE_LEFT = 0
                 val DRAWABLE_TOP = 1
@@ -144,7 +142,7 @@ abstract class AmityCommunityCreateBaseFragment : RxFragment() {
                 val DRAWABLE_BOTTOM = 3
 
                 if (event?.action == MotionEvent.ACTION_UP) {
-                    if (event.rawX >= (ccName.right - ccName.compoundDrawables[DRAWABLE_RIGHT].bounds.width())) {
+                    if (event.rawX >= (binding.ccName.right - binding.ccName.compoundDrawables[DRAWABLE_RIGHT].bounds.width())) {
                         viewModel.communityName.set("")
                     }
                 }
@@ -152,7 +150,7 @@ abstract class AmityCommunityCreateBaseFragment : RxFragment() {
             }
         })
 
-        etDescription.setOnTouchListener(object : View.OnTouchListener {
+        (binding.etDescription as View).setOnTouchListener(object : View.OnTouchListener {
             override fun onTouch(v: View?, event: MotionEvent?): Boolean {
                 val DRAWABLE_LEFT = 0
                 val DRAWABLE_TOP = 1
@@ -160,7 +158,7 @@ abstract class AmityCommunityCreateBaseFragment : RxFragment() {
                 val DRAWABLE_BOTTOM = 3
 
                 if (event?.action == MotionEvent.ACTION_UP) {
-                    if (event.rawX >= (etDescription.right - etDescription.compoundDrawables[DRAWABLE_RIGHT].bounds.width())) {
+                    if (event.rawX >= (binding.etDescription.right - binding.etDescription.compoundDrawables[DRAWABLE_RIGHT].bounds.width())) {
                         viewModel.description.set("")
                     }
                 }
@@ -228,7 +226,7 @@ abstract class AmityCommunityCreateBaseFragment : RxFragment() {
         if (isEditCommunity) {
             viewModel.initialStateChanged.set(false)
         } else {
-            mBinding.btnCreateCommunity.isEnabled = false
+            binding.btnCreateCommunity.isEnabled = false
         }
 
         if (imageUri != null) {
@@ -246,8 +244,7 @@ abstract class AmityCommunityCreateBaseFragment : RxFragment() {
                             }
                         }
                         is AmityUploadResult.ERROR, AmityUploadResult.CANCELLED -> {
-                            btnCreateCommunity.isEnabled = true
-                            mBinding.btnCreateCommunity.isEnabled = true
+                            binding.btnCreateCommunity.isEnabled = true
                             view?.showSnackBar(getString(R.string.amity_image_upload_error), Snackbar.LENGTH_SHORT)
                         }
                         else -> {
@@ -255,7 +252,7 @@ abstract class AmityCommunityCreateBaseFragment : RxFragment() {
                     }
                 }.doOnError {
                     Timber.e(TAG, "uploadImageAndCreateCommunity: ${it.localizedMessage}")
-                    mBinding.btnCreateCommunity.isEnabled = true
+                    binding.btnCreateCommunity.isEnabled = true
                     viewModel.initialStateChanged.set(true)
                 }.subscribe()
             )

--- a/social/src/main/java/com/amity/socialcloud/uikit/community/ui/view/AmityCommunityCreatorActivity.kt
+++ b/social/src/main/java/com/amity/socialcloud/uikit/community/ui/view/AmityCommunityCreatorActivity.kt
@@ -6,29 +6,33 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import com.amity.socialcloud.uikit.common.components.AmityToolBarClickListener
 import com.amity.socialcloud.uikit.community.R
-import kotlinx.android.synthetic.main.amity_activity_create_community.*
+import com.amity.socialcloud.uikit.community.databinding.AmityActivityCreateCommunityBinding
 
 class AmityCommunityCreatorActivity : AppCompatActivity(), AmityToolBarClickListener {
+
+    private val binding : AmityActivityCreateCommunityBinding by lazy {
+        AmityActivityCreateCommunityBinding.inflate(layoutInflater)
+    }
 
     private lateinit var mFragment: AmityCommunityCreatorFragment
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.amity_activity_create_community)
+        setContentView(binding.root)
         setUpToolBar()
         loadFragment()
     }
 
     private fun setUpToolBar() {
-        communityToolbar.setLeftDrawable(
+        binding.communityToolbar.setLeftDrawable(
             ContextCompat.getDrawable(this, R.drawable.amity_ic_cross)
         )
-        communityToolbar.setLeftString(getString(R.string.amity_create_community))
+        binding.communityToolbar.setLeftString(getString(R.string.amity_create_community))
 
-        communityToolbar.setClickListener(this)
+        binding.communityToolbar.setClickListener(this)
 
         supportActionBar?.displayOptions = ActionBar.DISPLAY_SHOW_CUSTOM
-        setSupportActionBar(communityToolbar)
+        setSupportActionBar(binding.communityToolbar)
     }
 
     private fun loadFragment() {

--- a/social/src/main/java/com/amity/socialcloud/uikit/community/ui/view/AmityCommunityCustomizeDialogFragment.kt
+++ b/social/src/main/java/com/amity/socialcloud/uikit/community/ui/view/AmityCommunityCustomizeDialogFragment.kt
@@ -10,10 +10,12 @@ import android.view.ViewGroup
 import android.view.Window
 import android.widget.FrameLayout
 import androidx.fragment.app.DialogFragment
-import com.amity.socialcloud.uikit.community.R
-import kotlinx.android.synthetic.main.amity_dialog_fragment_community_customize.*
+import com.amity.socialcloud.uikit.community.databinding.AmityDialogFragmentCommunityCustomizeBinding
 
 class AmityCommunityCustomizeDialogFragment : DialogFragment() {
+
+    private var _binding: AmityDialogFragmentCommunityCustomizeBinding? = null
+    private val binding get() = _binding!!
 
     private var listener: AmityCommunityCustomizeDialogFragmentListener? = null
 
@@ -21,12 +23,9 @@ class AmityCommunityCustomizeDialogFragment : DialogFragment() {
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
-        return inflater.inflate(
-            R.layout.amity_dialog_fragment_community_customize,
-            container,
-            false
-        )
+    ): View {
+        _binding = AmityDialogFragmentCommunityCustomizeBinding.inflate(inflater, container, false)
+        return binding.root
     }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
@@ -57,12 +56,12 @@ class AmityCommunityCustomizeDialogFragment : DialogFragment() {
     }
 
     private fun initialListener() {
-        button_community_settings.setOnClickListener {
+        binding.buttonCommunitySettings.setOnClickListener {
             listener?.onClickCommunitySettingsButton()
             dismiss()
         }
 
-        textview_skip.setOnClickListener {
+        binding.textviewSkip.setOnClickListener {
             listener?.onClickSkipButton()
             dismiss()
         }
@@ -70,6 +69,11 @@ class AmityCommunityCustomizeDialogFragment : DialogFragment() {
 
     fun setDialogListener(listener: AmityCommunityCustomizeDialogFragmentListener) {
         this.listener = listener
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     interface AmityCommunityCustomizeDialogFragmentListener {

--- a/social/src/main/java/com/amity/socialcloud/uikit/community/ui/view/AmityMemberPickerActivity.kt
+++ b/social/src/main/java/com/amity/socialcloud/uikit/community/ui/view/AmityMemberPickerActivity.kt
@@ -12,10 +12,13 @@ import com.amity.socialcloud.uikit.community.R
 import com.amity.socialcloud.uikit.community.data.AmitySelectMemberItem
 import com.amity.socialcloud.uikit.community.databinding.AmityActivitySelectMembersListBinding
 import com.amity.socialcloud.uikit.community.ui.viewModel.AmitySelectMembersViewModel
-import kotlinx.android.synthetic.main.amity_activity_select_members_list.*
 
 class AmityMemberPickerActivity : AmityBaseActivity<AmityActivitySelectMembersListBinding,
         AmitySelectMembersViewModel>(), AmityToolBarClickListener {
+
+    private val binding : AmityActivitySelectMembersListBinding by lazy {
+        AmityActivitySelectMembersListBinding.inflate(layoutInflater)
+    }
 
     private val mViewModel: AmitySelectMembersViewModel by viewModels()
     private lateinit var mFragment: AmityMemberPickerFragment
@@ -49,20 +52,22 @@ class AmityMemberPickerActivity : AmityBaseActivity<AmityActivitySelectMembersLi
     }
 
     private fun setUpToolBar() {
-        smToolBar.setLeftDrawable(
-                ContextCompat.getDrawable(this, R.drawable.amity_ic_arrow_back)
-        )
-        smToolBar.setRightString(getString(R.string.amity_done))
-        smToolBar.setClickListener(this)
+        binding.smToolBar.apply {
+            setLeftDrawable(
+                    ContextCompat.getDrawable(this@AmityMemberPickerActivity, R.drawable.amity_ic_arrow_back)
+            )
+            setRightString(getString(R.string.amity_done))
+            setClickListener(this@AmityMemberPickerActivity)
+        }
         setSelectionCount()
     }
 
     private fun setSelectionCount() {
         mViewModel.leftString.observe(this, Observer {
-            smToolBar.setLeftString(it)
+            binding.smToolBar.setLeftString(it)
         })
         mViewModel.rightStringActive.observe(this, Observer {
-            smToolBar.setRightStringActive(it)
+            binding.smToolBar.setRightStringActive(it)
         })
     }
 

--- a/social/src/main/java/com/amity/socialcloud/uikit/community/ui/view/AmityMemberPickerFragment.kt
+++ b/social/src/main/java/com/amity/socialcloud/uikit/community/ui/view/AmityMemberPickerFragment.kt
@@ -6,7 +6,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.activityViewModels
 import androidx.paging.PagedList
@@ -33,7 +32,6 @@ import com.trello.rxlifecycle3.components.support.RxFragment
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.schedulers.Schedulers
-import kotlinx.android.synthetic.main.amity_fragment_select_members_list.*
 
 private const val ARG_MEMBERS_LIST = "ARG_MEMBERS_LIST"
 
@@ -52,7 +50,7 @@ class AmityMemberPickerFragment : RxFragment(), AmitySelectMemberListener,
         CompositeDisposable()
     }
 
-    private lateinit var mBinding: AmityFragmentSelectMembersListBinding
+    private lateinit var binding: AmityFragmentSelectMembersListBinding
 
     companion object {
         fun newInstance(): Builder {
@@ -65,12 +63,12 @@ class AmityMemberPickerFragment : RxFragment(), AmitySelectMemberListener,
         savedInstanceState: Bundle?
     ): View {
         // Inflate the layout for this fragment
-        mBinding = DataBindingUtil.inflate(
+        binding = DataBindingUtil.inflate(
             inflater,
             R.layout.amity_fragment_select_members_list, container, false
         )
-        mBinding.viewModel = mViewModel
-        return mBinding.root
+        binding.viewModel = mViewModel
+        return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -82,7 +80,7 @@ class AmityMemberPickerFragment : RxFragment(), AmitySelectMemberListener,
         handleSelectedMembers()
         setUpMembersListRecyclerView()
 
-        etSearch.setShape(
+        binding.etSearch.setShape(
             null, null, null, null,
             R.color.amityColorBase, null, AmityColorShade.SHADE4
         )
@@ -135,28 +133,32 @@ class AmityMemberPickerFragment : RxFragment(), AmitySelectMemberListener,
         mSelectedMembersAdapter = AmitySelectedMemberAdapter(this)
         val layoutManager =
             LinearLayoutManager(requireContext(), LinearLayoutManager.HORIZONTAL, false)
-        rvSelectedMembers.layoutManager = layoutManager
-        rvSelectedMembers.adapter = mSelectedMembersAdapter
-        rvSelectedMembers.addItemDecoration(
-            AmityRecyclerViewItemDecoration(
-                0,
-                resources.getDimensionPixelSize(R.dimen.amity_padding_m2),
-                0,
-                resources.getDimensionPixelSize(R.dimen.amity_padding_xxs)
+        binding.rvSelectedMembers.apply {
+            this.layoutManager = layoutManager
+            adapter = mSelectedMembersAdapter
+            addItemDecoration(
+                    AmityRecyclerViewItemDecoration(
+                            0,
+                            resources.getDimensionPixelSize(R.dimen.amity_padding_m2),
+                            0,
+                            resources.getDimensionPixelSize(R.dimen.amity_padding_xxs)
+                    )
             )
-        )
+        }
     }
 
     private fun setUpMembersListRecyclerView() {
         mMemberListAdapter = AmityMembersListAdapter(this, mViewModel)
-        rvMembersList.layoutManager = LinearLayoutManager(requireContext())
-        rvMembersList.adapter = mMemberListAdapter
-        rvMembersList.addItemDecoration(
-            AmitySelectMembersItemDecoration(
-                resources.getDimensionPixelSize(R.dimen.amity_eighteen),
-                resources.getDimensionPixelSize(R.dimen.amity_padding_m1)
+        binding.rvMembersList.apply {
+            layoutManager = LinearLayoutManager(requireContext())
+            adapter = mMemberListAdapter
+            addItemDecoration(
+                    AmitySelectMembersItemDecoration(
+                            resources.getDimensionPixelSize(R.dimen.amity_eighteen),
+                            resources.getDimensionPixelSize(R.dimen.amity_padding_m1)
+                    )
             )
-        )
+        }
         disposable.add(mViewModel.getAllUsers().doOnError {
 
         }.subscribeOn(Schedulers.io())
@@ -168,14 +170,16 @@ class AmityMemberPickerFragment : RxFragment(), AmitySelectMemberListener,
 
     private fun setUpSearchRecyclerView() {
         mSearchResultAdapter = AmitySearchResultAdapter(this)
-        rvSearchResults.layoutManager = LinearLayoutManager(requireContext())
-        rvSearchResults.adapter = mSearchResultAdapter
-        rvSearchResults.addItemDecoration(
-            AmityRecyclerViewItemDecoration(
-                resources.getDimensionPixelSize(R.dimen.amity_padding_m1)
+        binding.rvSearchResults.apply {
+            layoutManager = LinearLayoutManager(requireContext())
+            adapter = mSearchResultAdapter
+            addItemDecoration(
+                    AmityRecyclerViewItemDecoration(
+                            resources.getDimensionPixelSize(R.dimen.amity_padding_m1)
+                    )
             )
-        )
-        (rvSearchResults.itemAnimator as SimpleItemAnimator).supportsChangeAnimations = false
+            (itemAnimator as SimpleItemAnimator).supportsChangeAnimations = false
+        }
     }
 
     override fun onMemberClicked(member: AmityUser, position: Int) {
@@ -193,7 +197,7 @@ class AmityMemberPickerFragment : RxFragment(), AmitySelectMemberListener,
             mViewModel.selectedMemberSet.add(member.getUserId())
             mViewModel.prepareSelectedMembersList(selectMemberItem, true)
             updateListOnSelection(member.getUserId())
-            rvSelectedMembers.scrollToPosition(mViewModel.selectedMembersList.size - 1)
+            binding.rvSelectedMembers.scrollToPosition(mViewModel.selectedMembersList.size - 1)
         }
     }
 

--- a/social/src/main/java/com/amity/socialcloud/uikit/community/views/AmityCommentComposeBar.kt
+++ b/social/src/main/java/com/amity/socialcloud/uikit/community/views/AmityCommentComposeBar.kt
@@ -14,10 +14,9 @@ import com.amity.socialcloud.uikit.common.common.views.AmityColorShade
 import com.amity.socialcloud.uikit.community.R
 import com.amity.socialcloud.uikit.community.databinding.AmityCommentComposeBarBinding
 import com.amity.socialcloud.uikit.community.views.comment.AmityCommentComposeView
-import kotlinx.android.synthetic.main.amity_comment_compose_bar.view.*
 
 class AmityCommentComposeBar : ConstraintLayout {
-    private lateinit var mBinding: AmityCommentComposeBarBinding
+    private lateinit var binding: AmityCommentComposeBarBinding
     private var commentExpandClickListener: OnClickListener? = null
 
 
@@ -38,7 +37,7 @@ class AmityCommentComposeBar : ConstraintLayout {
     }
 
     fun setImageUrl(url: String) {
-        mBinding.avatarUrl = url
+        binding.avatarUrl = url
     }
 
     fun setCommentExpandClickListener(onClickListener: OnClickListener) {
@@ -46,46 +45,47 @@ class AmityCommentComposeBar : ConstraintLayout {
     }
 
     fun getCommentEditText(): AmityCommentComposeView {
-        return mBinding.etPostComment
+        return binding.etPostComment
     }
 
     fun getTextCompose(): String {
-        return mBinding.etPostComment.text.toString()
+        return binding.etPostComment.text.toString()
     }
 
     fun getPostButton(): Button {
-        return mBinding.btnPost
+        return binding.btnPost
     }
 
     private fun init() {
         val inflater = context.getSystemService(Context.LAYOUT_INFLATER_SERVICE) as LayoutInflater
-        mBinding =
-            DataBindingUtil.inflate(inflater, R.layout.amity_comment_compose_bar, this, true)
-        avProfile.setBackgroundColor(
-            AmityColorPaletteUtil.getColor(
-                ContextCompat.getColor(context, R.color.amityColorPrimary), AmityColorShade.SHADE3
+        binding =
+                DataBindingUtil.inflate(inflater, R.layout.amity_comment_compose_bar, this, true)
+        binding.apply {
+            avProfile.setBackgroundColor(
+                    AmityColorPaletteUtil.getColor(
+                            ContextCompat.getColor(context, R.color.amityColorPrimary), AmityColorShade.SHADE3
+                    )
             )
-        )
-        btnPost.isEnabled = false
+            btnPost.isEnabled = false
 
-        etPostComment.addTextChangedListener(object : TextWatcher {
-            override fun afterTextChanged(s: Editable?) {
+            etPostComment.addTextChangedListener(object : TextWatcher {
+                override fun afterTextChanged(s: Editable?) {
 
+                }
+
+                override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {
+
+                }
+
+                override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
+                    btnPost.isEnabled = s.toString().trim().isNotEmpty()
+                }
+
+            })
+            ivExpand.setOnClickListener {
+                commentExpandClickListener?.onClick(it)
             }
-
-            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {
-
-            }
-
-            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
-                btnPost.isEnabled = s.toString().trim().isNotEmpty()
-            }
-
-        })
-        ivExpand.setOnClickListener {
-            commentExpandClickListener?.onClick(it)
         }
-
 
     }
 }

--- a/social/src/main/java/com/amity/socialcloud/uikit/community/views/communitycategory/AmityCommunityCategoryView.kt
+++ b/social/src/main/java/com/amity/socialcloud/uikit/community/views/communitycategory/AmityCommunityCategoryView.kt
@@ -10,10 +10,9 @@ import com.amity.socialcloud.sdk.social.community.AmityCommunityCategory
 import com.amity.socialcloud.uikit.community.R
 import com.amity.socialcloud.uikit.community.databinding.AmityItemCategoryListBinding
 import com.bumptech.glide.Glide
-import kotlinx.android.synthetic.main.amity_item_category_list.view.*
 
 class AmityCommunityCategoryView : ConstraintLayout {
-    private lateinit var mBinding: AmityItemCategoryListBinding
+    private lateinit var binding: AmityItemCategoryListBinding
 
 
     constructor(context: Context) : super(context) {
@@ -37,18 +36,18 @@ class AmityCommunityCategoryView : ConstraintLayout {
             .load(url)
             .placeholder(R.drawable.amity_ic_default_category_avatar)
             .centerCrop()
-            .into(categoryAvatar)
+            .into(binding.categoryAvatar)
     }
 
     fun setCategory(category: AmityCommunityCategory) {
-        tvCategoryName.text = category.getName()
-        mBinding.avatarUrl = category.getAvatar()?.getUrl(AmityImage.Size.SMALL)
+        binding.tvCategoryName.text = category.getName()
+        binding.avatarUrl = category.getAvatar()?.getUrl(AmityImage.Size.SMALL)
     }
 
 
     private fun init() {
         val inflater = context.getSystemService(Context.LAYOUT_INFLATER_SERVICE) as LayoutInflater
-        mBinding =
+        binding =
             DataBindingUtil.inflate(inflater, R.layout.amity_item_category_list, this, true)
 
     }

--- a/social/src/main/java/com/amity/socialcloud/uikit/community/views/newsfeed/AmityPostCommentView.kt
+++ b/social/src/main/java/com/amity/socialcloud/uikit/community/views/newsfeed/AmityPostCommentView.kt
@@ -25,7 +25,6 @@ import com.amity.socialcloud.uikit.community.newsfeed.events.CommentEngagementCl
 import com.amity.socialcloud.uikit.community.newsfeed.events.CommentOptionClickEvent
 import com.amity.socialcloud.uikit.community.newsfeed.listener.AmityMentionClickableSpan
 import io.reactivex.subjects.PublishSubject
-import kotlinx.android.synthetic.main.amity_item_comment_news_feed.view.*
 import timber.log.Timber
 
 class AmityPostCommentView : ConstraintLayout {
@@ -167,7 +166,7 @@ class AmityPostCommentView : ConstraintLayout {
     }
 
     private fun setText(comment: AmityComment) {
-        tvPostComment.text = getHighlightTextUserMentions(comment)
+        binding.tvPostComment.text = getHighlightTextUserMentions(comment)
     }
 
     private fun getHighlightTextUserMentions(comment: AmityComment): SpannableString {

--- a/social/src/main/java/com/amity/socialcloud/uikit/community/views/newsfeed/AmityPostItemFooter.kt
+++ b/social/src/main/java/com/amity/socialcloud/uikit/community/views/newsfeed/AmityPostItemFooter.kt
@@ -9,7 +9,6 @@ import androidx.paging.PagedList
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.amity.socialcloud.sdk.AmityCoreClient
 import com.amity.socialcloud.sdk.social.comment.AmityComment
-import com.amity.socialcloud.sdk.social.community.AmityCommunity
 import com.amity.socialcloud.sdk.social.feed.AmityPost
 import com.amity.socialcloud.uikit.common.common.readableNumber
 import com.amity.socialcloud.uikit.common.components.AmityDividerItemDecor
@@ -19,12 +18,10 @@ import com.amity.socialcloud.uikit.community.databinding.AmityItemPostFooterBind
 import com.amity.socialcloud.uikit.community.newsfeed.adapter.AmityFullCommentAdapter
 import com.amity.socialcloud.uikit.community.newsfeed.listener.*
 import com.amity.socialcloud.uikit.social.AmitySocialUISettings
-import kotlinx.android.synthetic.main.amity_item_post_footer.view.*
-
 
 class AmityPostItemFooter : ConstraintLayout {
 
-    private lateinit var mBinding: AmityItemPostFooterBinding
+    private lateinit var binding: AmityItemPostFooterBinding
     private var newsFeedCommentAdapter: AmityFullCommentAdapter? = null
 
     private var commentItemClickListener: AmityPostCommentItemClickListener? = null
@@ -56,15 +53,15 @@ class AmityPostItemFooter : ConstraintLayout {
 
     private fun init() {
         val inflater = context.getSystemService(Context.LAYOUT_INFLATER_SERVICE) as LayoutInflater
-        mBinding = AmityItemPostFooterBinding.inflate(inflater, this, true)
-        cbShare.setOnClickListener {
+        binding = AmityItemPostFooterBinding.inflate(inflater, this, true)
+        binding.cbShare.setOnClickListener {
             shareListener?.onShareAction()
         }
     }
 
     private fun setNumberOfComments(commentCount: Int) {
-        tvNumberOfComments.visibility = if (commentCount > 0) View.VISIBLE else View.GONE
-        tvNumberOfComments.text = context.resources.getQuantityString(
+        binding.tvNumberOfComments.visibility = if (commentCount > 0) View.VISIBLE else View.GONE
+        binding.tvNumberOfComments.text = context.resources.getQuantityString(
             R.plurals.amity_feed_number_of_comments,
             commentCount,
             commentCount
@@ -82,7 +79,7 @@ class AmityPostItemFooter : ConstraintLayout {
     }
 
     private fun setLikeClickListener(feed: AmityPost) {
-        cbLike.setOnClickListener {
+        binding.cbLike.setOnClickListener {
             val isLike = feed.getMyReactions().contains("like")
             refreshLikeView(!isLike)
             likeListener?.onLikeAction(!isLike)
@@ -90,7 +87,7 @@ class AmityPostItemFooter : ConstraintLayout {
     }
 
     private fun refreshLikeView(isLike: Boolean) {
-        cbLike.isChecked = isLike
+        binding.cbLike.isChecked = isLike
         setLikeCheckboxText()
     }
 
@@ -119,8 +116,8 @@ class AmityPostItemFooter : ConstraintLayout {
     }
 
     private fun setNumberOfLikes(reactionCount: Int) {
-        tvNumberOfLikes.visibility = if (reactionCount > 0) View.VISIBLE else View.GONE
-        tvNumberOfLikes.text = context.resources.getQuantityString(
+        binding.tvNumberOfLikes.visibility = if (reactionCount > 0) View.VISIBLE else View.GONE
+        binding.tvNumberOfLikes.text = context.resources.getQuantityString(
             R.plurals.amity_feed_number_of_likes,
             reactionCount,
             reactionCount.readableNumber()
@@ -128,10 +125,10 @@ class AmityPostItemFooter : ConstraintLayout {
     }
 
     private fun setLikeCheckboxText() {
-        if (cbLike.isChecked) {
-            cbLike.setText(R.string.amity_liked)
+        if (binding.cbLike.isChecked) {
+            binding.cbLike.setText(R.string.amity_liked)
         } else {
-            cbLike.setText(R.string.amity_like)
+            binding.cbLike.setText(R.string.amity_like)
         }
     }
 
@@ -179,12 +176,12 @@ class AmityPostItemFooter : ConstraintLayout {
         val space16 = resources.getDimensionPixelSize(R.dimen.amity_padding_m1)
         val spaceItemDecoration = AmityRecyclerViewItemDecoration(space8, space16, 0, space16)
         val itemDecor = AmityDividerItemDecor(context)
-        rvCommentFooter.addItemDecoration(spaceItemDecoration)
-        rvCommentFooter.addItemDecoration(itemDecor)
-        rvCommentFooter.layoutManager = LinearLayoutManager(context)
-        rvCommentFooter.adapter = newsFeedCommentAdapter
-        rvCommentFooter.visibility = GONE
-        separator2.visibility = GONE
+        binding.rvCommentFooter.addItemDecoration(spaceItemDecoration)
+        binding.rvCommentFooter.addItemDecoration(itemDecor)
+        binding.rvCommentFooter.layoutManager = LinearLayoutManager(context)
+        binding.rvCommentFooter.adapter = newsFeedCommentAdapter
+        binding.rvCommentFooter.visibility = GONE
+        binding.separator2.visibility = GONE
     }
 
     fun submitComments(commentList: PagedList<AmityComment>?, isScrollable: Boolean = false) {
@@ -194,14 +191,14 @@ class AmityPostItemFooter : ConstraintLayout {
         newsFeedCommentAdapter!!.submitList(commentList)
 
         if (newsFeedCommentAdapter!!.itemCount > 0) {
-            rvCommentFooter.visibility = VISIBLE
-            separator2.visibility = VISIBLE
+            binding.rvCommentFooter.visibility = VISIBLE
+            binding.separator2.visibility = VISIBLE
             if (isScrollable) {
-                rvCommentFooter.smoothScrollToPosition(0)
+                binding.rvCommentFooter.smoothScrollToPosition(0)
             }
         } else {
-            rvCommentFooter.visibility = GONE
-            separator2.visibility = GONE
+            binding.rvCommentFooter.visibility = GONE
+            binding.separator2.visibility = GONE
         }
     }
 
@@ -214,7 +211,7 @@ class AmityPostItemFooter : ConstraintLayout {
     }
 
     fun showViewAllComment(isVisible: Boolean) {
-        mBinding.showViewAllComment = isVisible
+        binding.showViewAllComment = isVisible
     }
 
     fun updateComment(comment: AmityComment) {


### PR DESCRIPTION
Kotlin synthetics has been deprecated and will [no longer works after end of 2022, when Kotlin 1.8 release](https://android-developers.googleblog.com/2022/02/discontinuing-kotlin-synthetics-for-views.html). It can also leads to having wrong imports and very error-prone compared to ViewBinding. This PR migrated away from Kotlin synthetics to ViewBinding.

- Removed all Kotlin synthetics and replace with equivalent View Binding 
- Remove Kotlin Android extension plugin
- Added `kotlin-parcelize` to keep the `@Parcelize` API
- Changed `mBinding` to `binding` during refactor

Since I couldn't run it locally on my machine, I wasn't able to test to make sure it behaves the same. Might need to clone and test it.