### PR TITLE
ASC-12847-fixed direction after post created

### DIFF
--- a/social/src/main/java/com/amity/socialcloud/uikit/community/newsfeed/fragment/AmityPostTargetPickerFragment.kt
+++ b/social/src/main/java/com/amity/socialcloud/uikit/community/newsfeed/fragment/AmityPostTargetPickerFragment.kt
@@ -37,7 +37,10 @@ class AmityPostTargetPickerFragment : AmityBaseFragment(),
             AmityPostCreatorActivity
                 .AmityCreateCommunityPostActivityContract()
         ) {
-            getCommunity()
+            if(it != null){
+                getCommunity()
+                handleBackPress()
+            }
         }
 
     private val createLiveStreamPost =
@@ -50,14 +53,20 @@ class AmityPostTargetPickerFragment : AmityBaseFragment(),
                     AmityPostDetailsActivity.newIntent(requireContext(), createdPostId, null, null)
                 startActivity(intent)
             }
-            getCommunity()
+            if(createdPostId != null){
+                getCommunity()
+                handleBackPress()
+            }
         }
 
     private val createPollPost = registerForActivityResult(
         AmityPollPostCreatorActivity
             .AmityPollCreatorActivityContract()
     ) {
-        getCommunity()
+        if(it != null){
+            getCommunity()
+            handleBackPress()
+        }
     }
 
     companion object {
@@ -123,10 +132,10 @@ class AmityPostTargetPickerFragment : AmityBaseFragment(),
             layoutManager = LinearLayoutManager(requireContext())
             this.adapter = communityAdapter
             addItemDecoration(
-                    AmityRecyclerViewItemDecoration(
-                            resources.getDimensionPixelSize(R.dimen.amity_padding_xs),
-                            0, resources.getDimensionPixelSize(R.dimen.amity_padding_xs)
-                    )
+                AmityRecyclerViewItemDecoration(
+                    resources.getDimensionPixelSize(R.dimen.amity_padding_xs),
+                    0, resources.getDimensionPixelSize(R.dimen.amity_padding_xs)
+                )
             )
             hasFixedSize()
         }


### PR DESCRIPTION
Summary
- I have added code to check the activity result, and if the post is successfully created, the app will navigate back to the page that was active before tapping the create button.

Changes Made
- added code to check the activity result. If it is not null, then handle the back press to navigate back 
code: 
if(it != null){
  getCommunity()
  handleBackPress()
}

Impact
- global feeds may not refresh to see the post just created

Testing
- I've successfully posted all types of content, including generic posts, live streams, and polls.
- I've tested posting on both the timeline and within a community.
- I've also tested posting from a button inside a community.

Targeted Fix Version
- SDK 6.6.0
- UIKit Open Source release-3.2-hydra

Documentation Changes
[Describe what changes in the public documentation, if applicable.]

Checklist
- [ / ] All tests pass successfully
- [ / ] Code adheres to the company's coding standards and best practices
- [ x ] Documentation has been updated (if applicable)
- [ x ] Code has been reviewed by at least one other Ninja or senior engineer
 
Next Steps
- no needed

Ticket - [Android : UIKit] App can't direct user to the news feed
https://ekoapp.atlassian.net/browse/ASC-12847